### PR TITLE
Converting string input data to Buffer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dist
 
 test/repo-just-for-test*
 /test/blocks
+
+# Vim .swp files
+**.swp

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const dagPB = require('ipld-dag-pb')
 dagPB.DAGNode.create  // create a DAGNode
 dagPB.DAGNode.clone   // clone a DAGNode
 dagPB.DAGNode.addLink // add a Link to a DAGNode, creating a new one
-dagPB.DAGNode.rmLinkq // remove a Link to a DAGNode, creating a new one
+dagPB.DAGNode.rmLink  // remove a Link to a DAGNode, creating a new one
 dagPB.DAGLink.create  // create a DAGLink
 
 // IPLD Format specifics
@@ -84,11 +84,15 @@ dagPB.util
 #### Create a DAGNode
 
 ```JavaScript
-DAGNode.create(new Buffer('some data'), (err, node) => {
+DAGNode.create(new Buffer('some data'), (err, node1) => {
   if (err) {
     throw error
   }
-  // node is your DAGNode instance
+  // node1 is your DAGNode instance.
+})
+
+DAGNode.create('string data', (err, node2) => {
+  // node2 will have the same data as node1.
 })
 ```
 

--- a/src/dag-node/create.js
+++ b/src/dag-node/create.js
@@ -13,6 +13,8 @@ function create (data, dagLinks, hashAlg, callback) {
   if (typeof data === 'function') {
     callback = data
     data = undefined
+  } else if (typeof data === 'string') {
+    data = new Buffer(data)
   }
   if (typeof dagLinks === 'function') {
     callback = dagLinks

--- a/src/dag-node/create.js
+++ b/src/dag-node/create.js
@@ -25,6 +25,10 @@ function create (data, dagLinks, hashAlg, callback) {
     hashAlg = undefined
   }
 
+  if (!Buffer.isBuffer(data)) {
+    return callback('Passed \'data\' is not a buffer or a string!')
+  }
+
   if (!hashAlg) {
     hashAlg = 'sha2-256'
   }

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -150,6 +150,18 @@ module.exports = (repo) => {
       })
     })
 
+    it('fail to create a node with other data types', (done) => {
+      DAGNode.create({}, (err, node) => {
+        expect(err).to.exist
+        expect(node).to.not.exist
+        DAGNode.create([], (err, node) => {
+          expect(err).to.exist
+          expect(node).to.not.exist
+          done()
+        })
+      })
+    })
+
     it('addLink by DAGNode', (done) => {
       let node1
       let node2

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -34,6 +34,29 @@ module.exports = (repo) => {
         expect(node.data.length).to.be.above(0).mark()
         expect(Buffer.isBuffer(node.data)).to.be.true.mark()
         expect(node.size).to.be.above(0).mark()
+        expect(node.toJSON().multihash).to.be.equal('Qmd7xRhW5f29QuBFtqu3oSD27iVy35NRB91XFjmKFhtgMr')
+
+        dagPB.util.serialize(node, (err, serialized) => {
+          expect(err).to.not.exist.mark()
+
+          dagPB.util.deserialize(serialized, (err, deserialized) => {
+            expect(err).to.not.exist.mark()
+            expect(node.data).to.eql(deserialized.data).mark()
+          })
+        })
+      })
+    })
+
+    it('create a node with string data', (done) => {
+      expect(7).checks(done)
+      const data = 'some data'
+
+      DAGNode.create(data, (err, node) => {
+        expect(err).to.not.exist.mark()
+        expect(node.data.length).to.be.above(0).mark()
+        expect(Buffer.isBuffer(node.data)).to.be.true.mark()
+        expect(node.size).to.be.above(0).mark()
+        expect(node.toJSON().multihash).to.be.equal('Qmd7xRhW5f29QuBFtqu3oSD27iVy35NRB91XFjmKFhtgMr')
 
         dagPB.util.serialize(node, (err, serialized) => {
           expect(err).to.not.exist.mark()


### PR DESCRIPTION
Basically, I ran into this because I mis-read the README and started putting in string data into `DAGNode.create`! If you do this, the current behaviour allows a number of odd/confusing scenarios, and it's not clear that you've done something wrong.

Currently, if a string is put in as the data, it will be accepted, and will work when put or gotten from IPFS, but it will break if you try and clone the DAGNode due to the line `dagNode.data.copy(data)` (js strings don't have a copy method).

Passing in string data seemed like a reasonable thing to do, but I felt converting the input data string to a buffer would be better than allowing the internal DAGNode data to be a string - I felt having two internal data representations would perhaps cause other unknown problems, however, I am open to reverse this!

Also fixed a small typo in the README, because why not :)