### PR TITLE
bs58 is a normal dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "protocol-buffers": "^3.2.1",
     "pull-stream": "^3.5.0",
     "pull-traverse": "^1.0.3",
-    "stable": "^0.1.5"
+    "stable": "^0.1.5",
+    "bs58": "^4.0.0"
   },
   "devDependencies": {
     "aegir": "^10.0.0",
-    "bs58": "^4.0.0",
     "buffer-loader": "0.0.1",
     "chai": "^3.5.0",
     "chai-checkmark": "^1.0.1",


### PR DESCRIPTION
It is used [here](https://github.com/ipld/js-ipld-dag-pb/blob/master/src/resolver.js#L4).