### PR TITLE
Fix false positives in isLink and update test

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const waterfall = require('async/waterfall')
+const CID = require('cids')
 
 const util = require('./util')
 
@@ -117,9 +118,17 @@ exports.isLink = (block, path, callback) => {
     }
 
     if (typeof result.value === 'object' && result.value['/']) {
-      callback(null, result.value)
-    } else {
-      callback(null, false)
+      let valid
+      try {
+        valid = CID.isCID(new CID(result.value['/']))
+      } catch (err) {
+        valid = false
+      }
+      if (valid) {
+        return callback(null, result.value)
+      }
     }
+
+    callback(null, false)
   })
 }

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -228,10 +228,16 @@ describe('IPLD Format resolver (local)', () => {
   })
 
   it('resolver.isLink for non valid CID', (done) => {
-    resolver.isLink(dataLinksNodeBlock, 'Links/0/Tsize', (err, link) => {
+    // blank value case
+    resolver.isLink(dataLinksNodeBlock, 'Links/0/Name', (err, link) => {
       expect(err).to.not.exist()
       expect(link).to.equal(false)
-      done()
+      // non-blank value case
+      resolver.isLink(dataLinksNodeBlock, 'Links/0/Tsize', (err, link) => {
+        expect(err).to.not.exist()
+        expect(link).to.equal(false)
+        done()
+      })
     })
   })
 })

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -228,7 +228,7 @@ describe('IPLD Format resolver (local)', () => {
   })
 
   it('resolver.isLink for non valid CID', (done) => {
-    resolver.isLink(dataLinksNodeBlock, 'Links/0/Name', (err, link) => {
+    resolver.isLink(dataLinksNodeBlock, 'Links/0/Tsize', (err, link) => {
       expect(err).to.not.exist()
       expect(link).to.equal(false)
       done()


### PR DESCRIPTION
The isLink method (formerly isCID) appears [intended](https://github.com/ipld/js-ipld-dag-pb/blob/master/test/resolver.spec.js#L222) to identify paths specifically to link hashes (as opposed to paths to link name or size), but currently falls into the `true` case for paths to any truthy values. The tests pass because the non-valid CID case happens to check a path to an empty value.

Discussion [here](https://github.com/ipfs/js-ipfs/pull/1045#discussion_r159034560).