### PR TITLE
chore: change from pre-commit to pre-push validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coverage": "aegir coverage",
     "coverage-publish": "aegir coverage publish"
   },
-  "pre-commit": [
+  "pre-push": [
     "lint",
     "test"
   ],
@@ -64,7 +64,7 @@
     "stable": "^0.1.6"
   },
   "devDependencies": {
-    "aegir": "^12.2.0",
+    "aegir": "^12.4.0",
     "chai": "^4.1.2",
     "chai-checkmark": "^1.0.1",
     "detect-node": "^2.0.3",
@@ -73,7 +73,6 @@
     "ipfs-repo": "~0.18.4",
     "lodash": "^4.17.4",
     "ncp": "^2.0.0",
-    "pre-commit": "^1.2.2",
     "rimraf": "^2.6.2"
   }
 }


### PR DESCRIPTION
Instead of running lint and test before every commit, run it before
every push.