### PR TITLE
fix: return deserialized node if no path is given

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -16,6 +16,14 @@ exports.resolve = (binaryBlob, path, callback) => {
   waterfall([
     (cb) => util.deserialize(binaryBlob, cb),
     (node, cb) => {
+      // Return the deserialized block if no path is given
+      if (!path) {
+        return callback(null, {
+          value: node,
+          remainderPath: ''
+        })
+      }
+
       const split = path.split('/')
 
       if (split[0] === 'Links') {

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -80,6 +80,16 @@ describe('IPLD Format resolver (local)', () => {
           done()
         })
       })
+
+      it('empty path', (done) => {
+        resolver.resolve(emptyNodeBlob, '', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value.data).to.eql(Buffer.alloc(0))
+          expect(result.value.links).to.eql([])
+          expect(result.remainderPath).to.eql('')
+          done()
+        })
+      })
     })
 
     it('resolver.tree', (done) => {
@@ -195,6 +205,16 @@ describe('IPLD Format resolver (local)', () => {
       it('non existent path', (done) => {
         resolver.resolve(dataLinksNodeBlob, 'pathThatDoesNotExist', (err, result) => {
           expect(err).to.exist()
+          done()
+        })
+      })
+
+      it('empty path', (done) => {
+        resolver.resolve(dataLinksNodeBlob, '', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value.data).to.eql(Buffer.from('aaah the data'))
+          expect(result.value.links.map((link) => link.toJSON())).to.eql(links)
+          expect(result.remainderPath).to.eql('')
           done()
         })
       })


### PR DESCRIPTION
In order to be similar to other IPLD formats, return the
full deserialized node if no path is given.