### PR TITLE
Revert "replace constructor.name with instanceof so uglify can mangle and compress"

### DIFF
--- a/src/dag-link/util.js
+++ b/src/dag-link/util.js
@@ -3,7 +3,7 @@
 const DAGLink = require('./index')
 
 function isDagLink (link) {
-  return link && link.constructor && link instanceof DAGLink
+  return link && link.constructor && link.constructor.name === 'DAGLink'
 }
 
 function createDagLinkFromB58EncodedHash (link) {

--- a/src/dag-node/addLink.js
+++ b/src/dag-node/addLink.js
@@ -6,16 +6,15 @@ const cloneData = dagNodeUtil.cloneData
 const toDAGLink = dagNodeUtil.toDAGLink
 const DAGLink = require('./../dag-link')
 const create = require('./create')
-const DAGNode = require('./index')
 
 function addLink (node, link, callback) {
   const links = cloneLinks(node)
   const data = cloneData(node)
 
-  if ((link.constructor && link instanceof DAGLink)) {
+  if ((link.constructor && link.constructor.name === 'DAGLink')) {
     // It's a DAGLink instance
     // no need to do anything
-  } else if (link.constructor && link instanceof DAGNode) {
+  } else if (link.constructor && link.constructor.name === 'DAGNode') {
     // It's a DAGNode instance
     // convert to link
     link = toDAGLink(link)

--- a/src/util.js
+++ b/src/util.js
@@ -19,7 +19,7 @@ function serialize (node, callback) {
   let serialized
 
   // If the node is not an instance of a DAGNode, the link.hash might be a Base58 encoded string; decode it
-  if (!(node instanceof DAGNode) && node.links) {
+  if (node.constructor.name !== 'DAGNode' && node.links) {
     node.links = node.links.map((link) => {
       return DAGLink.util.isDagLink(link) ? link : DAGLink.util.createDagLinkFromB58EncodedHash(link)
     })


### PR DESCRIPTION
Quoting @dignifiedquire: "there is a reason we don‘t use instanceof anywhere. It breaks for consumers using the library if they bundle a different set of code or the class."

Reverts ipld/js-ipld-dag-pb#58.