### PR TITLE
chore: changing all dependencies < 1.0 to `~`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,16 +56,16 @@
   "dependencies": {
     "async": "^2.6.0",
     "bs58": "^4.0.1",
-    "buffer-loader": "0.0.1",
-    "cids": "^0.5.3",
+    "buffer-loader": "~0.0.1",
+    "cids": "~0.5.3",
     "class-is": "^1.1.0",
     "is-ipfs": "~0.3.2",
     "multihashes": "~0.4.13",
-    "multihashing-async": "^0.4.8",
+    "multihashing-async": "~0.4.8",
     "protons": "^1.0.1",
     "pull-stream": "^3.6.7",
     "pull-traverse": "^1.0.3",
-    "stable": "^0.1.6"
+    "stable": "~0.1.6"
   },
   "devDependencies": {
     "aegir": "^13.0.6",


### PR DESCRIPTION
According to the IPFS JS Guidelines all packages lower than version 1.0
should be prefixed with a tilde.