### PR TITLE
fix: lock stable dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "protons": "^1.0.1",
     "pull-stream": "^3.6.7",
     "pull-traverse": "^1.0.3",
-    "stable": "~0.1.6"
+    "stable": "0.1.6"
   },
   "devDependencies": {
     "aegir": "^13.0.6",


### PR DESCRIPTION
This PR locks the `stable` dependecy to a working version, as the latest one breaks all the browser tests.

Fixes https://github.com/ipld/js-ipld-dag-pb/issues/65.