### PR TITLE
fix: Initialise the DAGLink name to empty string if a falsey value is passed

### DIFF
--- a/src/dag-link/index.js
+++ b/src/dag-link/index.js
@@ -12,7 +12,7 @@ class DAGLink {
     //  note - links should include size, but this assert is disabled
     //  for now to maintain consistency with go-ipfs pinset
 
-    this._name = name
+    this._name = name || ''
     this._size = size
 
     if (typeof multihash === 'string') {

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -134,6 +134,29 @@ module.exports = (repo) => {
       })
     })
 
+    it('create with undefined link name', (done) => {
+      waterfall([
+        (cb) => DAGNode.create(Buffer.from('hello'), [
+          new DAGLink(undefined, 10, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+        ], cb),
+        (node, cb) => {
+          expect(node.links[0].name).to.be.eql('')
+
+          waterfall([
+            (cb) => dagPB.util.serialize(node, cb),
+            (buffer, cb) => dagPB.util.deserialize(buffer, cb),
+            (deserialized, cb) => {
+              Object.getOwnPropertyNames(node).forEach(key => {
+                expect(node[key]).to.deep.equal(deserialized[key])
+              })
+
+              cb()
+            }
+          ], cb)
+        }
+      ], done)
+    })
+
     it('create an empty node', (done) => {
       // this node is not in the repo as we don't copy node data to the browser
       expect(7).checks(done)


### PR DESCRIPTION
Changes the behaviour of `new DAGLink(...)` to default the link name to an empty string, otherwise you can get odd behaviour as detailed in ipld/js-ipld#125 where you fetch a `DAGNode` using a `CID` and it is returned with a different `CID` to the one you used to fetch it..