### PR TITLE
fix: unlock and update stable dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "protons": "^1.0.1",
     "pull-stream": "^3.6.7",
     "pull-traverse": "^1.0.3",
-    "stable": "0.1.6"
+    "stable": "~0.1.8"
   },
   "devDependencies": {
     "aegir": "^13.0.6",


### PR DESCRIPTION
A new version of stable has been released that fixes an error that was breaking the browser tests.
So we can now unlock the stable dependency and update its version.