### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 > JavaScript Implementation of the IPLD Format MerkleDAG Node in Protobuf. In addition to the IPLD Format methods, this module also provides an API for creating the nodes and manipulating them (adding and removing links, etc).
 
+## Lead Maintainer
+
+[Volker Mische](https://github.com/vmx)
+
 ## Table of Contents
 
 - [Install](#install)
@@ -51,7 +55,6 @@
   - [`dagPB.util.cid`](#dagpbutilcid)
   - [`dagPB.util.serialize`](#dagpbutilserialize)
   - [`dagPB.util.deserialize`](#dagpbutildeserialize)
-- [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -293,10 +296,6 @@ const link = new DAGLink(name, size, multihash)
 ### `dagPB.util.serialize`
 
 ### `dagPB.util.deserialize`
-
-## Maintainers
-
-[@diasdavid](https://github.com/diasdavid)
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipld-dag-pb",
   "version": "0.14.4",
   "description": "JavaScript Implementation of the MerkleDAG Node in Protobuf.",
+  "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "scripts": {
     "test": "aegir test",
@@ -19,7 +20,6 @@
     "lint",
     "test"
   ],
-  "author": "Vijayee Kulkaa <vijayee.kulkaa@hushmail.com>",
   "contributors": [
     "Adam Stone <AdamStone@users.noreply.github.com>",
     "Arpit Agarwal <atvanguard@users.noreply.github.com>",


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md