### PR TITLE
fix: pass serialized blob to util.cid

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -18,9 +18,9 @@ exports = module.exports
  * @param {?CID} cid - CID if call was successful
  */
 /**
- * Get the CID of the DAG-Node.
+ * Get the CID of the serialized ProtoBuf node.
  *
- * @param {Buffer} blob - Serialized binary data
+ * @param {Buffer} blob - Serialized ProtoBuf node
  * @param {Object} [options] - Options to create the CID
  * @param {number} [options.version] - CID version number. Defaults to zero if hashAlg == 'sha2-256'; otherwise, 1.
  * @param {string} [options.hashAlg] - Defaults to hashAlg for the resolver

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('assert')
 const CID = require('cids')
 const protons = require('protons')
 const proto = protons(require('./dag.proto.js'))
@@ -19,14 +20,15 @@ exports = module.exports
 /**
  * Get the CID of the DAG-Node.
  *
- * @param {Object} dagNode - Internal representation
+ * @param {Buffer} blob - Serialized binary data
  * @param {Object} [options] - Options to create the CID
  * @param {number} [options.version] - CID version number. Defaults to zero if hashAlg == 'sha2-256'; otherwise, 1.
  * @param {string} [options.hashAlg] - Defaults to hashAlg for the resolver
  * @param {CidCallback} callback - Callback that handles the return value
  * @returns {void}
  */
-function cid (dagNode, options, callback) {
+function cid (blob, options, callback) {
+  assert(Buffer.isBuffer(blob), 'blob must be a Buffer')
   if (typeof options === 'function') {
     callback = options
     options = {}
@@ -38,8 +40,7 @@ function cid (dagNode, options, callback) {
     version = hashAlg === 'sha2-256' ? 0 : 1
   }
   waterfall([
-    (cb) => serialize(dagNode, cb),
-    (serialized, cb) => multihashing(serialized, hashAlg, cb),
+    (cb) => multihashing(blob, hashAlg, cb),
     (mh, cb) => cb(null, new CID(version, resolver.multicodec, mh))
   ], callback)
 }

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -424,14 +424,17 @@ module.exports = (repo) => {
     it('get node CID', (done) => {
       DAGNode.create(Buffer.from('some data'), (err, node) => {
         expect(err).to.not.exist()
-        util.cid(node, (err, cid) => {
+        util.serialize(node, (err, serialized) => {
           expect(err).to.not.exist()
-          expect(cid.multihash).to.exist()
-          expect(cid.codec).to.equal('dag-pb')
-          expect(cid.version).to.equal(0)
-          const mh = multihash.decode(cid.multihash)
-          expect(mh.name).to.equal('sha2-256')
-          done()
+          util.cid(serialized, (err, cid) => {
+            expect(err).to.not.exist()
+            expect(cid.multihash).to.exist()
+            expect(cid.codec).to.equal('dag-pb')
+            expect(cid.version).to.equal(0)
+            const mh = multihash.decode(cid.multihash)
+            expect(mh.name).to.equal('sha2-256')
+            done()
+          })
         })
       })
     })
@@ -439,14 +442,17 @@ module.exports = (repo) => {
     it('get node CID with hashAlg', (done) => {
       DAGNode.create(Buffer.from('some data'), (err, node) => {
         expect(err).to.not.exist()
-        util.cid(node, { hashAlg: 'sha2-512' }, (err, cid) => {
+        util.serialize(node, (err, serialized) => {
           expect(err).to.not.exist()
-          expect(cid.multihash).to.exist()
-          expect(cid.codec).to.equal('dag-pb')
-          expect(cid.version).to.equal(1)
-          const mh = multihash.decode(cid.multihash)
-          expect(mh.name).to.equal('sha2-512')
-          done()
+          util.cid(serialized, { hashAlg: 'sha2-512' }, (err, cid) => {
+            expect(err).to.not.exist()
+            expect(cid.multihash).to.exist()
+            expect(cid.codec).to.equal('dag-pb')
+            expect(cid.version).to.equal(1)
+            const mh = multihash.decode(cid.multihash)
+            expect(mh.name).to.equal('sha2-512')
+            done()
+          })
         })
       })
     })


### PR DESCRIPTION
BREAKING CHANGE: the first argument is now the serialized output NOT the dag node.
See https://github.com/ipld/interface-ipld-format/issues/32