### PR TITLE
fix: add support for resolving links by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -57,6 +57,8 @@ exports.resolve = (binaryBlob, path, callback) => {
           values[link.name] = link.multihash
         })
 
+        console.log(values)
+
         let value = values[split[1]]
 
         // if remainderPath exists, value needs to be CID
@@ -74,7 +76,33 @@ exports.resolve = (binaryBlob, path, callback) => {
       } else if (split[0] === 'Data') {
         cb(null, { value: node.data, remainderPath: '' })
       } else {
-        cb(new Error('path not available'))
+        const values = {}
+
+        // populate both index number and name to enable both cases
+        // for the resolver
+        node.links.forEach((l, i) => {
+          const link = l.toJSON()
+          values[i] = {
+            hash: link.multihash,
+            name: link.name,
+            size: link.size
+          }
+          // TODO by enabling something to resolve through link name, we are
+          // applying a transformation (a view) to the data, confirm if this
+          // is exactly what we want
+          values[link.name] = link.multihash
+        })
+
+        const val = values[split[0]]
+
+        if (val) {
+          return cb(null, {
+            value: { '/': val.hash },
+            remainderPath: split.slice(3).join('/')
+          })
+        } else {
+          cb(new Error('path not available'))
+        }
       }
     }
   ], callback)

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -46,9 +46,6 @@ exports.resolve = (binaryBlob, path, callback) => {
         // for the resolver
         node.links.forEach((l, i) => {
           const link = l.toJSON()
-          // TODO by enabling something to resolve through link name, we are
-          // applying a transformation (a view) to the data, confirm if this
-          // is exactly what we want
           values[i] = values[link.name] = {
             hash: link.multihash,
             name: link.name,
@@ -73,16 +70,15 @@ exports.resolve = (binaryBlob, path, callback) => {
       } else if (split[0] === 'Data') {
         cb(null, { value: node.data, remainderPath: '' })
       } else {
+        // If split[0] is not 'Data' or 'Links' then we might be trying to refer
+        // to a named link from the Links array. This is because go-ipfs and
+        // js-ipfs have historically supported the ability to do
+        // `ipfs dag get CID/a` where a is a named link in a dag-pb.
         const values = {}
 
-        // populate both index number and name to enable both cases
-        // for the resolver
         node.links.forEach((l, i) => {
           const link = l.toJSON()
-          // TODO by enabling something to resolve through link name, we are
-          // applying a transformation (a view) to the data, confirm if this
-          // is exactly what we want
-          values[i] = values[link.name] = {
+          values[link.name] = {
             hash: link.multihash,
             name: link.name,
             size: link.size

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -46,18 +46,15 @@ exports.resolve = (binaryBlob, path, callback) => {
         // for the resolver
         node.links.forEach((l, i) => {
           const link = l.toJSON()
-          values[i] = {
+          // TODO by enabling something to resolve through link name, we are
+          // applying a transformation (a view) to the data, confirm if this
+          // is exactly what we want
+          values[i] = values[link.name] = {
             hash: link.multihash,
             name: link.name,
             size: link.size
           }
-          // TODO by enabling something to resolve through link name, we are
-          // applying a transformation (a view) to the data, confirm if this
-          // is exactly what we want
-          values[link.name] = link.multihash
         })
-
-        console.log(values)
 
         let value = values[split[1]]
 
@@ -82,27 +79,26 @@ exports.resolve = (binaryBlob, path, callback) => {
         // for the resolver
         node.links.forEach((l, i) => {
           const link = l.toJSON()
-          values[i] = {
+          // TODO by enabling something to resolve through link name, we are
+          // applying a transformation (a view) to the data, confirm if this
+          // is exactly what we want
+          values[i] = values[link.name] = {
             hash: link.multihash,
             name: link.name,
             size: link.size
           }
-          // TODO by enabling something to resolve through link name, we are
-          // applying a transformation (a view) to the data, confirm if this
-          // is exactly what we want
-          values[link.name] = link.multihash
         })
 
-        const val = values[split[0]]
+        const value = values[split[0]]
 
-        if (val) {
+        if (value) {
           return cb(null, {
-            value: { '/': val.hash },
-            remainderPath: split.slice(3).join('/')
+            value: { '/': value.hash },
+            remainderPath: split.slice(1).join('/')
           })
-        } else {
-          cb(new Error('path not available'))
         }
+
+        cb(new Error('path not available'))
       }
     }
   ], callback)

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -146,6 +146,15 @@ describe('IPLD Format resolver (local)', () => {
         })
       })
 
+      it('links by name', (done) => {
+        resolver.resolve(linksNodeBlob, 'named link', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value['/']).to.eql(links[1].multihash)
+          expect(result.remainderPath).to.eql('')
+          done()
+        })
+      })
+
       it('yield remainderPath if impossible to resolve through (a)', (done) => {
         resolver.resolve(linksNodeBlob, 'Links/1/Hash/Data', (err, result) => {
           expect(err).to.not.exist()

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -155,6 +155,14 @@ describe('IPLD Format resolver (local)', () => {
         })
       })
 
+      it('missing link by name', (done) => {
+        resolver.resolve(linksNodeBlob, 'missing link', (err, result) => {
+          expect(err).to.exist()
+          expect(err.message).to.equal('path not available')
+          done()
+        })
+      })
+
       it('yield remainderPath if impossible to resolve through (a)', (done) => {
         resolver.resolve(linksNodeBlob, 'Links/1/Hash/Data', (err, result) => {
           expect(err).to.not.exist()
@@ -167,6 +175,27 @@ describe('IPLD Format resolver (local)', () => {
 
       it('yield remainderPath if impossible to resolve through (b)', (done) => {
         resolver.resolve(linksNodeBlob, 'Links/1/Hash/Links/0/Hash/Data', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value['/'])
+            .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
+
+          expect(result.remainderPath).to.equal('Links/0/Hash/Data')
+          done()
+        })
+      })
+
+      it('yield remainderPath if impossible to resolve through named link (a)', (done) => {
+        resolver.resolve(linksNodeBlob, 'named link/Data', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value['/']).to.exist()
+          expect(result.value['/']).to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
+          expect(result.remainderPath).to.equal('Data')
+          done()
+        })
+      })
+
+      it('yield remainderPath if impossible to resolve through named link (b)', (done) => {
+        resolver.resolve(linksNodeBlob, 'named link/Links/0/Hash/Data', (err, result) => {
           expect(err).to.not.exist()
           expect(result.value['/'])
             .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')


### PR DESCRIPTION
This is just a stab at fixing the _resolve links by name_ on dag-pb nodes. This PR is not finished (at all) but it shows what is missing.

Short story: go-ipfs and js-ipfs historically have supported the ability to do `jsipfs dag get CID/a` where a is a named link in a dag-pb.

So a dag-pb node like this.

```
{
  Data: <some data>
  Links: [
    {
       Name: a
       Hash: b58...
       Size: 1000
    }
  ]
}
```

Should support resolving the link through name so that both `jsipfs dag get CID/a` and `jsipfs dag get CID/Links/0/Hash` are equivalent.

