### PR TITLE
perf: make this._json calculation lazy

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "cids": "~0.5.3",
     "class-is": "^1.1.0",
     "is-ipfs": "~0.4.2",
-    "multihashes": "~0.4.13",
     "multihashing-async": "~0.5.1",
     "protons": "^1.0.1",
     "pull-stream": "^3.6.8",
@@ -78,6 +77,7 @@
     "ipfs-block-service": "~0.14.0",
     "ipfs-repo": "~0.22.1",
     "lodash": "^4.17.10",
+    "multihashes": "~0.4.13",
     "ncp": "^2.0.0",
     "rimraf": "^2.6.2"
   }

--- a/src/dag-link/index.js
+++ b/src/dag-link/index.js
@@ -14,27 +14,23 @@ class DAGLink {
 
     this._name = name || ''
     this._size = size
-
-    if (typeof multihash === 'string') {
-      const cid = new CID(multihash)
-      this._multihash = cid.buffer
-    } else if (Buffer.isBuffer(multihash)) {
-      this._multihash = multihash
-    }
+    this._cid = new CID(multihash)
   }
 
   toString () {
-    const cid = new CID(this.multihash)
-    return `DAGLink <${cid.toBaseEncodedString()} - name: "${this.name}", size: ${this.size}>`
+    return `DAGLink <${this._cid.toBaseEncodedString()} - name: "${this.name}", size: ${this.size}>`
   }
 
   toJSON () {
-    const cid = new CID(this.multihash)
-    return {
-      name: this.name,
-      size: this.size,
-      multihash: cid.toBaseEncodedString()
+    if (!this._json) {
+      this._json = Object.freeze({
+        name: this.name,
+        size: this.size,
+        multihash: this._cid.toBaseEncodedString()
+      })
     }
+
+    return this._json
   }
 
   get name () {
@@ -54,7 +50,7 @@ class DAGLink {
   }
 
   get multihash () {
-    return this._multihash
+    return this._cid.buffer
   }
 
   set multihash (multihash) {

--- a/src/dag-node/addLink.js
+++ b/src/dag-node/addLink.js
@@ -21,9 +21,8 @@ function addLink (node, link, callback) {
     link = toDAGLink(link)
   } else {
     // It's a Object with name, multihash/link and size
-    link.multihash = link.multihash || link.hash
     try {
-      link = new DAGLink(link.name, link.size, link.multihash)
+      link = new DAGLink(link.name, link.size, link.multihash || link.hash)
     } catch (err) {
       return callback(err)
     }

--- a/test/dag-link-test.js
+++ b/test/dag-link-test.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
-const mh = require('multihashes')
+const CID = require('cids')
 const DAGLink = require('../src').DAGLink
 
 module.exports = (repo) => {
@@ -26,7 +26,7 @@ module.exports = (repo) => {
       it('create with multihash as a multihash Buffer', () => {
         const link = new DAGLink('hello', 3, Buffer.from('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43', 'hex'))
 
-        expect(mh.toB58String(link.multihash))
+        expect(new CID(link.multihash).toBaseEncodedString())
           .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
       })
 

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -362,7 +362,7 @@ module.exports = (repo) => {
           })
         },
         (cb) => {
-          const link = toDAGLink(node2).toJSON()
+          const link = Object.assign({}, toDAGLink(node2).toJSON())
           link.name = 'banana'
 
           DAGNode.addLink(node1a, link, (err, node) => {
@@ -402,7 +402,7 @@ module.exports = (repo) => {
           })
         },
         (cb) => {
-          const link = toDAGLink(node2).toJSON()
+          const link = Object.assign({}, toDAGLink(node2).toJSON())
           link.name = 'banana'
 
           DAGNode.addLink(node1a, link, (err, node) => {


### PR DESCRIPTION
I've been doing some profiling of js-ipfs and where there are large amounts of DAG operations being performed (importing all of npm to ipfs, for example) we spend about 1.8-2.5% of our time in the creation of this._json objects, even though they are not always used, so this PR makes them be
created when first requested.

It also passes the `this._json` object through `Object.freeze` because otherwise we expose a mutable object to the world - it seems odd that we've taken pains to ensure that the properties of a DAGNode/DAGLink are immutable, then expose objects whose properties are not immutable.

Finally it makes more use of the `cids` module to parse CIDs from multihashes as the `cids` module respects CIDv1 versions/codecs if present whereas the `multihashes` module does not and is only really suitable for use with CIDv0.