### PR TITLE
fix: allow mutating returned .toJSON value

### DIFF
--- a/src/dag-link/index.js
+++ b/src/dag-link/index.js
@@ -30,7 +30,7 @@ class DAGLink {
       })
     }
 
-    return this._json
+    return Object.assign({}, this._json)
   }
 
   get name () {

--- a/src/dag-node/index.js
+++ b/src/dag-node/index.js
@@ -25,7 +25,7 @@ class DAGNode {
       })
     }
 
-    return this._json
+    return Object.assign({}, this._json)
   }
 
   toString () {

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -362,7 +362,7 @@ module.exports = (repo) => {
           })
         },
         (cb) => {
-          const link = Object.assign({}, toDAGLink(node2).toJSON())
+          const link = toDAGLink(node2).toJSON()
           link.name = 'banana'
 
           DAGNode.addLink(node1a, link, (err, node) => {
@@ -402,7 +402,7 @@ module.exports = (repo) => {
           })
         },
         (cb) => {
-          const link = Object.assign({}, toDAGLink(node2).toJSON())
+          const link = toDAGLink(node2).toJSON()
           link.name = 'banana'
 
           DAGNode.addLink(node1a, link, (err, node) => {


### PR DESCRIPTION
Relaxes the constraints from ipld/js-ipld-dag-pb#81 a little as it's caused quite a lot of tests to break.

We still have an immutable copy in the object but any objects returned will be mutable.