### PR TITLE
fix: resolve link Name or Tsize

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -59,9 +59,9 @@ exports.resolve = (binaryBlob, path, callback) => {
         if (split[2] === 'Hash') {
           value = { '/': value.hash }
         } else if (split[2] === 'Tsize') {
-          value = { '/': value.size }
+          value = value.size
         } else if (split[2] === 'Name') {
-          value = { '/': value.name }
+          value = value.name
         }
 
         remainderPath = split.slice(3).join('/')

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -131,7 +131,7 @@ describe('IPLD Format resolver (local)', () => {
       it('links position path Name', (done) => {
         resolver.resolve(linksNodeBlob, 'Links/1/Name', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value['/']).to.eql(links[1].name)
+          expect(result.value).to.eql(links[1].name)
           expect(result.remainderPath).to.eql('')
           done()
         })
@@ -140,7 +140,7 @@ describe('IPLD Format resolver (local)', () => {
       it('links position path Tsize', (done) => {
         resolver.resolve(linksNodeBlob, 'Links/1/Tsize', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value['/']).to.eql(links[1].size)
+          expect(result.value).to.eql(links[1].size)
           expect(result.remainderPath).to.eql('')
           done()
         })


### PR DESCRIPTION
Resolve to the value of Name or Tsize, do not wrap in IPLD link object.

fixes #85