### PR TITLE
chore: remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "async": "^2.6.1",
     "bs58": "^4.0.1",
-    "buffer-loader": "~0.1.0",
     "cids": "~0.5.4",
     "class-is": "^1.1.0",
     "is-ipfs": "~0.4.2",


### PR DESCRIPTION
`buffer-loader` isn't really used, thanks @alanshaw
[for finding](https://github.com/ipld/js-ipld-dag-pb/pull/87#issuecomment-424018639).