### PR TITLE
BREAKING CHANGE: Remove .cid, .multihash and .serialized properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Creates a new DAGNode instance with the union of node.links plus the new link.
 {
   name: '<some string>', // optional
   size: <size in bytes>,
-  cid: <cid> // can be a String CID or CID buffer
+  cid: <cid> // can be a String CID, CID buffer or CID object
 }
 ```
 
@@ -186,7 +186,7 @@ Creates a new DAGNode instance with the union of node.links plus the new link.
 #### rmLink(node, nameOrCid, callback)
 
 - `node` - type: DAGNode
-- `nameOrCid` - type: String or CID buffer
+- `nameOrCid` - type: String, CID object or CID buffer
 - `callback` - type: function with signature `function (err, node) {}`
 
 Removes a link from the node by name. Returns a *new* instance of DAGNode without modifying the old one.
@@ -242,7 +242,7 @@ const DAGLink = dagPB.DAGLink
 DAGLink.create(
   'link-to-file',  // name of the link (can be empty)
   10,              // size in bytes
-  'QmSomeHash...', // can be cid buffer or string
+  'QmSomeHash...', // can be CID object, CID buffer or string
   (err, link) => {
     if (err) {
       throw err

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
     - [Add and remove a Link](#add-and-remove-a-link)
 - [API](#api)
   - [DAGNode functions](#dagnode-functions)
-    - [DAGNode.create(data, links, hashAlg, callback)](#dagnodecreatedata-links-hashalg-callback)
+    - [DAGNode.create(data, links, callback)](#dagnodecreatedata-links-callback)
     - [addLink(node, link, callback)](#addlinknode-link-callback)
     - [rmLink(node, nameOrCid, callback)](#rmlinknode-nameorcid-callback)
     - [clone(node, callback)](#clonenode-callback)
@@ -134,11 +134,10 @@ const dagPB = require('ipld-dag-pb')
 const DAGNode = dagPB.DAGNode
 ```
 
-#### DAGNode.create(data, links, hashAlg, callback)
+#### DAGNode.create(data, links, callback)
 
 - `data` - type: Buffer
 - `links`- type: Array of DAGLink instances or Array of DAGLink instances in its json format (link.toJSON)
-- `hashAlg` - type: String
 - `callback` - type: function with signature `function (err, node) {}`
 
 Create a DAGNode.
@@ -181,7 +180,6 @@ Creates a new DAGNode instance with the union of node.links plus the new link.
   cid: <cid> // can be a String CID, CID buffer or CID object
 }
 ```
-
 
 #### rmLink(node, nameOrCid, callback)
 

--- a/README.md
+++ b/README.md
@@ -28,22 +28,20 @@
   - [DAGNode functions](#dagnode-functions)
     - [DAGNode.create(data, links, hashAlg, callback)](#dagnodecreatedata-links-hashalg-callback)
     - [addLink(node, link, callback)](#addlinknode-link-callback)
-    - [rmLink(node, nameOrMultihash, callback)](#rmlinknode-nameormultihash-callback)
+    - [rmLink(node, nameOrCid, callback)](#rmlinknode-nameorcid-callback)
     - [clone(node, callback)](#clonenode-callback)
   - [DAGNode instance methods and properties](#dagnode-instance-methods-and-properties)
     - [`node.data`](#nodedata)
     - [`node.links`](#nodelinks)
     - [`node.size`](#nodesize)
-    - [`node.multihash`](#nodemultihash)
-    - [`node.serialized`](#nodeserialized)
     - [`node.toJSON()`](#nodetojson)
     - [`node.toString()`](#nodetostring)
   - [DAGLink functions](#daglink-functions)
-    - [DAGLink.create(name, size, multihash, callback)](#daglinkcreatename-size-multihash-callback)
+    - [DAGLink.create(name, size, cid, callback)](#daglinkcreatename-size-cid-callback)
   - [DAGLink instance methods and properties](#daglink-instance-methods-and-properties)
     - [`link.name`](#linkname)
     - [`link.size`](#linksize)
-    - [`link.multihash`](#linkmultihash)
+    - [`link.cid`](#linkcid)
     - [`link.toJSON()`](#linktojson)
     - [`link.toString()`](#linktostring)
   - [[IPLD Format Specifics](https://github.com/ipld/interface-ipld-format) - Local (node/block scope) resolver](#ipld-format-specificshttpsgithubcomipldinterface-ipld-format---local-nodeblock-scope-resolver)
@@ -101,7 +99,7 @@ DAGNode.create('some data', (err, node2) => {
 ```JavaScript
 const link = {
   name: 'I am a link',
-  multihash: 'QmHash..',
+  cid: 'QmHash..',
   size: 42
 }
 
@@ -156,7 +154,7 @@ links can be a single or an array of DAGLinks instances or objects with the foll
 ```JavaScript
 {
   name: '<some name>',
-  hash: '<some multihash>', // can also be `multihash: <some multihash>`
+  cid: '<some cid>',
   size: <sizeInBytes>
 }
 ```
@@ -167,7 +165,7 @@ links can be a single or an array of DAGLinks instances or objects with the foll
 - `link` - type: DAGLink or DAGLink in its json format
 - `callback` - type: function with signature `function (err, node) {}`
 
-Creates a link on node A to node B by using node B to get its multihash. Returns a *new* instance of DAGNode without modifying the old one.
+Creates a link on node A to node B by using node B to get its CID. Returns a *new* instance of DAGNode without modifying the old one.
 
 Creates a new DAGNode instance with the union of node.links plus the new link.
 
@@ -180,21 +178,21 @@ Creates a new DAGNode instance with the union of node.links plus the new link.
 {
   name: '<some string>', // optional
   size: <size in bytes>,
-  multihash: <multihash> // can be a String multihash or multihash buffer
+  cid: <cid> // can be a String CID or CID buffer
 }
 ```
 
 
-#### rmLink(node, nameOrMultihash, callback)
+#### rmLink(node, nameOrCid, callback)
 
 - `node` - type: DAGNode
-- `nameOrMultihash` - type: String or multihash buffer
+- `nameOrCid` - type: String or CID buffer
 - `callback` - type: function with signature `function (err, node) {}`
 
 Removes a link from the node by name. Returns a *new* instance of DAGNode without modifying the old one.
 
 ```JavaScript
-DAGNode.rmLink(node, 'Link1' (err, dagNode) => ...) 
+DAGNode.rmLink(node, 'Link1' (err, dagNode) => ...)
 ```
 
 #### clone(node, callback)
@@ -222,10 +220,6 @@ An array of `DAGLinks`
 
 Size of the node, in bytes
 
-#### `node.multihash`
-
-#### `node.serialized`
-
 #### `node.toJSON()`
 
 #### `node.toString()`
@@ -233,7 +227,7 @@ Size of the node, in bytes
 
 ### DAGLink functions
 
-Following the same pattern as [`DAGNode functions`]() above, DAGLink also offers a function for its creation. 
+Following the same pattern as [`DAGNode functions`]() above, DAGLink also offers a function for its creation.
 
 You can incude it in your project with:
 
@@ -242,13 +236,13 @@ const dagPB = require('ipld-dag-pb')
 const DAGLink = dagPB.DAGLink
 ```
 
-#### DAGLink.create(name, size, multihash, callback)
+#### DAGLink.create(name, size, cid, callback)
 
 ```JavaScript
 DAGLink.create(
   'link-to-file',  // name of the link (can be empty)
   10,              // size in bytes
-  'QmSomeHash...', // can be multihash buffer or string
+  'QmSomeHash...', // can be cid buffer or string
   (err, link) => {
     if (err) {
       throw err
@@ -260,7 +254,7 @@ DAGLink.create(
 Note: DAGLinks are simpler objects and can be instantiated directly:
 
 ```JavaScript
-const link = new DAGLink(name, size, multihash)
+const link = new DAGLink(name, size, cid)
 ```
 
 ### DAGLink instance methods and properties
@@ -269,7 +263,7 @@ const link = new DAGLink(name, size, multihash)
 
 #### `link.size`
 
-#### `link.multihash`
+#### `link.cid`
 
 #### `link.toJSON()`
 

--- a/src/dag-link/create.js
+++ b/src/dag-link/create.js
@@ -2,8 +2,8 @@
 
 const DAGLink = require('./index.js')
 
-function create (name, size, multihash, callback) {
-  const link = new DAGLink(name, size, multihash)
+function create (name, size, cid, callback) {
+  const link = new DAGLink(name, size, cid)
   callback(null, link)
 }
 

--- a/src/dag-link/index.js
+++ b/src/dag-link/index.js
@@ -6,15 +6,15 @@ const withIs = require('class-is')
 
 // Link represents an IPFS Merkle DAG Link between Nodes.
 class DAGLink {
-  constructor (name, size, multihash) {
-    assert(multihash, 'A link requires a multihash to point to')
+  constructor (name, size, cid) {
+    assert(cid, 'A link requires a cid to point to')
     // assert(size, 'A link requires a size')
     //  note - links should include size, but this assert is disabled
     //  for now to maintain consistency with go-ipfs pinset
 
     this._name = name || ''
     this._size = size
-    this._cid = new CID(multihash)
+    this._cid = new CID(cid)
   }
 
   toString () {
@@ -26,7 +26,7 @@ class DAGLink {
       this._json = Object.freeze({
         name: this.name,
         size: this.size,
-        multihash: this._cid.toBaseEncodedString()
+        cid: this._cid.toBaseEncodedString()
       })
     }
 
@@ -47,14 +47,6 @@ class DAGLink {
 
   set size (size) {
     throw new Error("Can't set property: 'size' is immutable")
-  }
-
-  get multihash () {
-    return this._cid.buffer
-  }
-
-  set multihash (multihash) {
-    throw new Error("Can't set property: 'multihash' is immutable")
   }
 
   get cid () {

--- a/src/dag-link/util.js
+++ b/src/dag-link/util.js
@@ -6,7 +6,7 @@ function createDagLinkFromB58EncodedHash (link) {
   return new DAGLink(
     link.name ? link.name : link.Name,
     link.size ? link.size : link.Size,
-    link.hash || link.Hash || link.multihash
+    link.hash || link.Hash || link.multihash || link.cid
   )
 }
 

--- a/src/dag-node/addLink.js
+++ b/src/dag-node/addLink.js
@@ -8,28 +8,40 @@ const DAGLink = require('../dag-link')
 const DAGNode = require('./index')
 const create = require('./create')
 
+function asDAGLink (link, callback) {
+  if (DAGLink.isDAGLink(link)) {
+    // It's a DAGLink instance
+    // no need to do anything
+
+    return callback(null, link)
+  }
+
+  if (DAGNode.isDAGNode(link)) {
+    // It's a DAGNode instance
+    // convert to link
+    return toDAGLink(link, {}, callback)
+  }
+
+  // It's a Object with name, multihash/hash/cid and size
+  try {
+    callback(null, new DAGLink(link.name, link.size, link.multihash || link.hash || link.cid))
+  } catch (err) {
+    return callback(err)
+  }
+}
+
 function addLink (node, link, callback) {
   const links = cloneLinks(node)
   const data = cloneData(node)
 
-  if (DAGLink.isDAGLink(link)) {
-    // It's a DAGLink instance
-    // no need to do anything
-  } else if (DAGNode.isDAGNode(link)) {
-    // It's a DAGNode instance
-    // convert to link
-    link = toDAGLink(link)
-  } else {
-    // It's a Object with name, multihash/link and size
-    try {
-      link = new DAGLink(link.name, link.size, link.multihash || link.hash)
-    } catch (err) {
-      return callback(err)
+  asDAGLink(link, (error, link) => {
+    if (error) {
+      return callback(error)
     }
-  }
 
-  links.push(link)
-  create(data, links, callback)
+    links.push(link)
+    create(data, links, callback)
+  })
 }
 
 module.exports = addLink

--- a/src/dag-node/create.js
+++ b/src/dag-node/create.js
@@ -1,57 +1,43 @@
 'use strict'
 
-const multihashing = require('multihashing-async')
 const sort = require('stable')
-const dagPBUtil = require('../util.js')
-const serialize = dagPBUtil.serialize
+const {
+  serialize
+} = require('../util.js')
 const dagNodeUtil = require('./util.js')
 const linkSort = dagNodeUtil.linkSort
 const DAGNode = require('./index.js')
 const DAGLink = require('../dag-link')
 
-function create (data, dagLinks, hashAlg, callback) {
+function create (data, links, callback) {
   if (typeof data === 'function') {
     callback = data
     data = undefined
   } else if (typeof data === 'string') {
     data = Buffer.from(data)
   }
-  if (typeof dagLinks === 'function') {
-    callback = dagLinks
-    dagLinks = []
-  }
-  if (typeof hashAlg === 'function') {
-    callback = hashAlg
-    hashAlg = undefined
+  if (typeof links === 'function') {
+    callback = links
+    links = []
   }
 
   if (!Buffer.isBuffer(data)) {
     return callback(new Error('Passed \'data\' is not a buffer or a string!'))
   }
 
-  if (!hashAlg) {
-    hashAlg = 'sha2-256'
-  }
-
-  const links = dagLinks.map((link) => {
+  links = links.map((link) => {
     return DAGLink.isDAGLink(link) ? link : DAGLink.util.createDagLinkFromB58EncodedHash(link)
   })
-  const sortedLinks = sort(links, linkSort)
+  links = sort(links, linkSort)
 
   serialize({
-    data: data,
-    links: sortedLinks
-  }, (err, serialized) => {
+    data, links
+  }, (err, buffer) => {
     if (err) {
       return callback(err)
     }
-    multihashing(serialized, hashAlg, (err, multihash) => {
-      if (err) {
-        return callback(err)
-      }
-      const dagNode = new DAGNode(data, sortedLinks, serialized, multihash)
-      callback(null, dagNode)
-    })
+
+    callback(null, new DAGNode(data, links, buffer.length))
   })
 }
 

--- a/src/dag-node/index.js
+++ b/src/dag-node/index.js
@@ -2,17 +2,16 @@
 
 const assert = require('assert')
 const withIs = require('class-is')
-const CID = require('cids')
 
 class DAGNode {
-  constructor (data, links, serialized, multihash) {
-    assert(serialized, 'DAGNode needs its serialized format')
-    assert(multihash, 'DAGNode needs its multihash')
+  constructor (data, links, serializedSize) {
+    if (serializedSize !== 0) {
+      assert(serializedSize, 'A DAGNode requires it\'s serialized size')
+    }
 
-    this._cid = new CID(multihash)
     this._data = data || Buffer.alloc(0)
     this._links = links || []
-    this._serialized = serialized
+    this._serializedSize = serializedSize
   }
 
   toJSON () {
@@ -20,7 +19,6 @@ class DAGNode {
       this._json = Object.freeze({
         data: this.data,
         links: this.links.map((l) => l.toJSON()),
-        multihash: this._cid.toBaseEncodedString(),
         size: this.size
       })
     }
@@ -29,7 +27,7 @@ class DAGNode {
   }
 
   toString () {
-    return `DAGNode <${this._cid.toBaseEncodedString()} - data: "${this.data.toString()}", links: ${this.links.length}, size: ${this.size}>`
+    return `DAGNode <data: "${this.data.toString('base64')}", links: ${this.links.length}, size: ${this.size}>`
   }
 
   get data () {
@@ -48,17 +46,9 @@ class DAGNode {
     throw new Error("Can't set property: 'links' is immutable")
   }
 
-  get serialized () {
-    return this._serialized
-  }
-
-  set serialized (serialized) {
-    throw new Error("Can't set property: 'serialized' is immutable")
-  }
-
   get size () {
     if (this._size === undefined) {
-      this._size = this.links.reduce((sum, l) => sum + l.size, this.serialized.length)
+      this._size = this.links.reduce((sum, l) => sum + l.size, this._serializedSize)
     }
 
     return this._size
@@ -66,22 +56,6 @@ class DAGNode {
 
   set size (size) {
     throw new Error("Can't set property: 'size' is immutable")
-  }
-
-  get multihash () {
-    return this._cid.buffer
-  }
-
-  set multihash (multihash) {
-    throw new Error("Can't set property: 'multihash' is immutable")
-  }
-
-  get cid () {
-    return this._cid
-  }
-
-  set cid (cid) {
-    throw new Error("Can't set property: 'cid' is immutable")
   }
 }
 

--- a/src/dag-node/rmLink.js
+++ b/src/dag-node/rmLink.js
@@ -4,17 +4,18 @@ const dagNodeUtil = require('./util')
 const cloneLinks = dagNodeUtil.cloneLinks
 const cloneData = dagNodeUtil.cloneData
 const create = require('./create')
+const CID = require('cids')
 
-function rmLink (dagNode, nameOrMultihash, callback) {
+function rmLink (dagNode, nameOrCid, callback) {
   const data = cloneData(dagNode)
   let links = cloneLinks(dagNode)
 
-  if (typeof nameOrMultihash === 'string') {
-    links = links.filter((link) => link.name !== nameOrMultihash)
-  } else if (Buffer.isBuffer(nameOrMultihash)) {
-    links = links.filter((link) => !link.multihash.equals(nameOrMultihash))
+  if (typeof nameOrCid === 'string') {
+    links = links.filter((link) => link.name !== nameOrCid)
+  } else if (Buffer.isBuffer(nameOrCid) || CID.isCID(nameOrCid)) {
+    links = links.filter((link) => !link.cid.equals(nameOrCid))
   } else {
-    return callback(new Error('second arg needs to be a name or multihash'), null)
+    return callback(new Error('second arg needs to be a name or CID'), null)
   }
 
   create(data, links, callback)

--- a/src/dag-node/util.js
+++ b/src/dag-node/util.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const DAGLink = require('./../dag-link')
+const {
+  cid
+} = require('../util')
 
 exports = module.exports
 
@@ -31,8 +34,19 @@ function linkSort (a, b) {
 /*
  * toDAGLink converts a DAGNode to a DAGLink
  */
-function toDAGLink (node) {
-  return new DAGLink('', node.size, node.multihash)
+function toDAGLink (node, options, callback) {
+  if (typeof options === 'function') {
+    callback = options
+    options = {}
+  }
+
+  cid(node, options, (error, cid) => {
+    if (error) {
+      return callback(error)
+    }
+
+    callback(null, new DAGLink(options.name || '', node.size, cid))
+  })
 }
 
 exports.cloneData = cloneData

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -47,7 +47,7 @@ exports.resolve = (binaryBlob, path, callback) => {
         node.links.forEach((l, i) => {
           const link = l.toJSON()
           values[i] = values[link.name] = {
-            hash: link.multihash,
+            cid: link.cid,
             name: link.name,
             size: link.size
           }
@@ -57,7 +57,7 @@ exports.resolve = (binaryBlob, path, callback) => {
 
         // if remainderPath exists, value needs to be CID
         if (split[2] === 'Hash') {
-          value = { '/': value.hash }
+          value = { '/': value.cid }
         } else if (split[2] === 'Tsize') {
           value = value.size
         } else if (split[2] === 'Name') {
@@ -79,7 +79,7 @@ exports.resolve = (binaryBlob, path, callback) => {
         node.links.forEach((l, i) => {
           const link = l.toJSON()
           values[link.name] = {
-            hash: link.multihash,
+            cid: link.cid,
             name: link.name,
             size: link.size
           }
@@ -89,7 +89,7 @@ exports.resolve = (binaryBlob, path, callback) => {
 
         if (value) {
           return cb(null, {
-            value: { '/': value.hash },
+            value: { '/': value.cid },
             remainderPath: split.slice(1).join('/')
           })
         }

--- a/test/dag-link-test.js
+++ b/test/dag-link-test.js
@@ -14,7 +14,7 @@ module.exports = (repo) => {
       it('string', () => {
         const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
 
-        expect(link.multihash.toString('hex'))
+        expect(link.cid.buffer.toString('hex'))
           .to.equal('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43')
       })
 
@@ -26,7 +26,7 @@ module.exports = (repo) => {
       it('create with multihash as a multihash Buffer', () => {
         const link = new DAGLink('hello', 3, Buffer.from('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43', 'hex'))
 
-        expect(new CID(link.multihash).toBaseEncodedString())
+        expect(new CID(link.cid).toBaseEncodedString())
           .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
       })
 
@@ -44,7 +44,7 @@ module.exports = (repo) => {
       expect(link.toJSON()).to.eql({
         name: 'hello',
         size: 3,
-        multihash: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'
+        cid: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'
       })
     })
 

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -272,9 +272,10 @@ module.exports = (repo) => {
             cb()
           })
         },
-        (cb) => toDAGLink(node2.toJSON(), cb),
+        (cb) => toDAGLink(node2, cb),
         (link, cb) => {
-          DAGNode.addLink(node1, link, (err, node1b) => {
+          const linkObject = link.toJSON()
+          DAGNode.addLink(node1, linkObject, (err, node1b) => {
             expect(err).to.not.exist()
             expect(node1b.links.length).to.equal(1)
             expect(node1b.links[0].size)

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -41,7 +41,6 @@ module.exports = (repo) => {
         expect(node.data.length).to.be.above(0).mark()
         expect(Buffer.isBuffer(node.data)).to.be.true.mark()
         expect(node.size).to.be.above(0).mark()
-        expect(node.toJSON().multihash).to.be.equal('Qmd7xRhW5f29QuBFtqu3oSD27iVy35NRB91XFjmKFhtgMr')
 
         dagPB.util.serialize(node, (err, serialized) => {
           expect(err).to.not.exist.mark()
@@ -63,7 +62,6 @@ module.exports = (repo) => {
         expect(node.data.length).to.be.above(0).mark()
         expect(Buffer.isBuffer(node.data)).to.be.true.mark()
         expect(node.size).to.be.above(0).mark()
-        expect(node.toJSON().multihash).to.be.equal('Qmd7xRhW5f29QuBFtqu3oSD27iVy35NRB91XFjmKFhtgMr')
 
         dagPB.util.serialize(node, (err, serialized) => {
           expect(err).to.not.exist.mark()
@@ -114,7 +112,6 @@ module.exports = (repo) => {
       ], (err) => {
         expect(err).to.not.exist()
         expect(node1.toJSON()).to.eql(node2.toJSON())
-        expect(node1.serialized).to.eql(node2.serialized)
 
         // check sorting
         expect(node1.links.map((l) => l.name)).to.be.eql([
@@ -161,13 +158,11 @@ module.exports = (repo) => {
     it('create an empty node', (done) => {
       // this node is not in the repo as we don't copy node data to the browser
       expect(7).checks(done)
-      const fromGoIPFS = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
 
       DAGNode.create(Buffer.alloc(0), (err, node) => {
         expect(err).to.not.exist.mark()
         expect(node.data.length).to.be.equal(0).mark()
         expect(Buffer.isBuffer(node.data)).to.be.true.mark()
-        expect(node.toJSON().multihash).to.eql(fromGoIPFS)
         expect(node.size).to.be.equal(0).mark()
 
         dagPB.util.serialize(node, (err, serialized) => {
@@ -216,8 +211,6 @@ module.exports = (repo) => {
           DAGNode.addLink(node1, node2, (err, node1b) => {
             expect(err).to.not.exist()
             expect(node1b.links.length).to.equal(1)
-            expect(node1b.links[0].multihash)
-              .to.eql(node2.multihash)
             expect(node1b.links[0].size)
               .to.eql(node2.size)
             expect(node1b.links[0].name).to.be.eql('')
@@ -231,7 +224,7 @@ module.exports = (repo) => {
       let node1
       let node2
 
-      series([
+      waterfall([
         (cb) => {
           DAGNode.create(Buffer.from('1'), (err, node) => {
             expect(err).to.not.exist()
@@ -246,14 +239,11 @@ module.exports = (repo) => {
             cb()
           })
         },
-        (cb) => {
-          const link = toDAGLink(node2)
-
+        (cb) => toDAGLink(node2, cb),
+        (link, cb) => {
           DAGNode.addLink(node1, link, (err, node1b) => {
             expect(err).to.not.exist()
             expect(node1b.links.length).to.equal(1)
-            expect(node1b.links[0].multihash)
-              .to.eql(node2.multihash)
             expect(node1b.links[0].size)
               .to.eql(node2.size)
             expect(node1b.links[0].name).to.be.eql('')
@@ -267,7 +257,7 @@ module.exports = (repo) => {
       let node1
       let node2
 
-      series([
+      waterfall([
         (cb) => {
           DAGNode.create(Buffer.from('1'), (err, node) => {
             expect(err).to.not.exist()
@@ -282,14 +272,11 @@ module.exports = (repo) => {
             cb()
           })
         },
-        (cb) => {
-          const link = toDAGLink(node2).toJSON()
-
+        (cb) => toDAGLink(node2, cb),
+        (link, cb) => {
           DAGNode.addLink(node1, link, (err, node1b) => {
             expect(err).to.not.exist()
             expect(node1b.links.length).to.equal(1)
-            expect(node1b.links[0].multihash)
-              .to.eql(node2.multihash)
             expect(node1b.links[0].size)
               .to.eql(node2.size)
             expect(node1b.links[0].name).to.be.eql('')
@@ -346,7 +333,7 @@ module.exports = (repo) => {
       let node1b
       let node2
 
-      series([
+      waterfall([
         (cb) => {
           DAGNode.create(Buffer.from('1'), (err, node) => {
             expect(err).to.not.exist()
@@ -361,10 +348,10 @@ module.exports = (repo) => {
             cb()
           })
         },
-        (cb) => {
-          const link = toDAGLink(node2).toJSON()
-          link.name = 'banana'
-
+        (cb) => toDAGLink(node2, {
+          name: 'banana'
+        }, cb),
+        (link, cb) => {
           DAGNode.addLink(node1a, link, (err, node) => {
             expect(err).to.not.exist()
             node1b = node
@@ -386,7 +373,7 @@ module.exports = (repo) => {
       let node1b
       let node2
 
-      series([
+      waterfall([
         (cb) => {
           DAGNode.create(Buffer.from('1'), (err, node) => {
             expect(err).to.not.exist()
@@ -401,10 +388,10 @@ module.exports = (repo) => {
             cb()
           })
         },
-        (cb) => {
-          const link = toDAGLink(node2).toJSON()
-          link.name = 'banana'
-
+        (cb) => toDAGLink(node2, {
+          name: 'banana'
+        }, cb),
+        (link, cb) => {
           DAGNode.addLink(node1a, link, (err, node) => {
             expect(err).to.not.exist()
             node1b = node
@@ -412,7 +399,7 @@ module.exports = (repo) => {
           })
         },
         (cb) => {
-          DAGNode.rmLink(node1b, node2.multihash, (err, node) => {
+          DAGNode.rmLink(node1b, node1b.links[0].cid, (err, node) => {
             expect(err).to.not.exist()
             expect(node1a.toJSON()).to.eql(node.toJSON())
             cb()
@@ -458,8 +445,14 @@ module.exports = (repo) => {
 
         waterfall([
           (cb) => dagPB.util.serialize(node, cb),
-          (s, cb) => {
-            block = new Block(s, new CID(node.multihash))
+          (s, cb) => dagPB.util.cid(s, (err, cid) => {
+            cb(err, {
+              buffer: s,
+              cid: cid
+            })
+          }),
+          ({ buffer, cid }, cb) => {
+            block = new Block(buffer, cid)
             bs.put(block, cb)
           },
           (cb) => bs.get(block.cid, cb),
@@ -496,37 +489,37 @@ module.exports = (repo) => {
       const expectedLinks = [
         {
           name: '',
-          multihash: 'QmSbCgdsX12C4KDw3PDmpBN9iCzS87a5DjgSCoW9esqzXk',
+          cid: 'QmSbCgdsX12C4KDw3PDmpBN9iCzS87a5DjgSCoW9esqzXk',
           size: 45623854
         },
         {
           name: '',
-          multihash: 'Qma4GxWNhywSvWFzPKtEswPGqeZ9mLs2Kt76JuBq9g3fi2',
+          cid: 'Qma4GxWNhywSvWFzPKtEswPGqeZ9mLs2Kt76JuBq9g3fi2',
           size: 45623854
         },
         {
           name: '',
-          multihash: 'QmQfyxyys7a1e3mpz9XsntSsTGc8VgpjPj5BF1a1CGdGNc',
+          cid: 'QmQfyxyys7a1e3mpz9XsntSsTGc8VgpjPj5BF1a1CGdGNc',
           size: 45623854
         },
         {
           name: '',
-          multihash: 'QmSh2wTTZT4N8fuSeCFw7wterzdqbE93j1XDhfN3vQHzDV',
+          cid: 'QmSh2wTTZT4N8fuSeCFw7wterzdqbE93j1XDhfN3vQHzDV',
           size: 45623854
         },
         {
           name: '',
-          multihash: 'QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK',
+          cid: 'QmVXsSVjwxMsCwKRCUxEkGb4f4B98gXVy3ih3v4otvcURK',
           size: 45623854
         },
         {
           name: '',
-          multihash: 'QmZjhH97MEYwQXzCqSQbdjGDhXWuwW4RyikR24pNqytWLj',
+          cid: 'QmZjhH97MEYwQXzCqSQbdjGDhXWuwW4RyikR24pNqytWLj',
           size: 45623854
         },
         {
           name: '',
-          multihash: 'QmRs6U5YirCqC7taTynz3x2GNaHJZ3jDvMVAzaiXppwmNJ',
+          cid: 'QmRs6U5YirCqC7taTynz3x2GNaHJZ3jDvMVAzaiXppwmNJ',
           size: 32538395
         }
       ]
@@ -535,8 +528,12 @@ module.exports = (repo) => {
         expect(err).to.not.exist()
         const nodeJSON = node.toJSON()
         expect(nodeJSON.links).to.eql(expectedLinks)
-        expect(nodeJSON.multihash).to.eql('QmQqy2SiEkKgr2cw5UbQ93TtLKEMsD8TdcWggR8q9JabjX')
-        done()
+
+        dagPB.util.cid(node, (err, cid) => {
+          expect(err).to.not.exist()
+          expect(cid.toBaseEncodedString()).to.eql('QmQqy2SiEkKgr2cw5UbQ93TtLKEMsD8TdcWggR8q9JabjX')
+          done()
+        })
       })
     })
 
@@ -546,22 +543,22 @@ module.exports = (repo) => {
       const expectedLinks = [
         {
           name: 'audio_only.m4a',
-          multihash: 'QmaUAwAQJNtvUdJB42qNbTTgDpzPYD1qdsKNtctM5i7DGB',
+          cid: 'QmaUAwAQJNtvUdJB42qNbTTgDpzPYD1qdsKNtctM5i7DGB',
           size: 23319629
         },
         {
           name: 'chat.txt',
-          multihash: 'QmNVrxbB25cKTRuKg2DuhUmBVEK9NmCwWEHtsHPV6YutHw',
+          cid: 'QmNVrxbB25cKTRuKg2DuhUmBVEK9NmCwWEHtsHPV6YutHw',
           size: 996
         },
         {
           name: 'playback.m3u',
-          multihash: 'QmUcjKzDLXBPmB6BKHeKSh6ZoFZjss4XDhMRdLYRVuvVfu',
+          cid: 'QmUcjKzDLXBPmB6BKHeKSh6ZoFZjss4XDhMRdLYRVuvVfu',
           size: 116
         },
         {
           name: 'zoom_0.mp4',
-          multihash: 'QmQqy2SiEkKgr2cw5UbQ93TtLKEMsD8TdcWggR8q9JabjX',
+          cid: 'QmQqy2SiEkKgr2cw5UbQ93TtLKEMsD8TdcWggR8q9JabjX',
           size: 306281879
         }
       ]
@@ -570,8 +567,12 @@ module.exports = (repo) => {
         expect(err).to.not.exist()
         const nodeJSON = node.toJSON()
         expect(nodeJSON.links).to.eql(expectedLinks)
-        expect(nodeJSON.multihash).to.eql('QmbSAC58x1tsuPBAoarwGuTQAgghKvdbKSBC8yp5gKCj5M')
-        done()
+
+        dagPB.util.cid(node, (err, cid) => {
+          expect(err).to.not.exist()
+          expect(cid.toBaseEncodedString()).to.eql('QmbSAC58x1tsuPBAoarwGuTQAgghKvdbKSBC8yp5gKCj5M')
+          done()
+        })
       })
     })
 
@@ -580,7 +581,6 @@ module.exports = (repo) => {
         expect(err).to.not.exist()
         expect(node.toJSON().data).to.eql(Buffer.alloc(0))
         expect(node.toJSON().links).to.eql([])
-        expect(node.toJSON().multihash).to.exist()
         expect(node.toJSON().size).to.exist()
         done()
       })
@@ -592,7 +592,6 @@ module.exports = (repo) => {
         expect(err).to.not.exist()
         expect(node.toJSON().data).to.eql(data)
         expect(node.toJSON().links).to.eql([])
-        expect(node.toJSON().multihash).to.exist()
         expect(node.toJSON().size).to.exist()
         done()
       })
@@ -623,7 +622,7 @@ module.exports = (repo) => {
     it('toString', (done) => {
       DAGNode.create(Buffer.from('hello world'), (err, node) => {
         expect(err).to.not.exist()
-        const expected = 'DAGNode <QmU1Sq1B7RPQD2XcQNLB58qJUyJffVJqihcxmmN1STPMxf - data: "hello world", links: 0, size: 13>'
+        const expected = 'DAGNode <data: "aGVsbG8gd29ybGQ=", links: 0, size: 13>'
         expect(node.toString()).to.equal(expected)
         done()
       })
@@ -645,7 +644,6 @@ module.exports = (repo) => {
         expect(node.data.length).to.be.above(0).mark()
         expect(Buffer.isBuffer(node.data)).to.be.true.mark()
         expect(node.size).to.be.above(0).mark()
-        expect(node.toJSON().multihash).to.be.equal('QmR2W8uRZuVfUk8YtuAH3ezJwJzMuVbuehL2NAc4TmAz93')
 
         dagPB.util.serialize(node, (err, serialized) => {
           expect(err).to.not.exist.mark()
@@ -663,27 +661,5 @@ module.exports = (repo) => {
         })
       })
     }).timeout(6000)
-
-    it('exposes a CID', (done) => {
-      DAGNode.create(Buffer.from('hello world'), (err, node) => {
-        expect(err).to.not.exist()
-        expect(node.cid.toBaseEncodedString()).to.equal('QmU1Sq1B7RPQD2XcQNLB58qJUyJffVJqihcxmmN1STPMxf')
-        done()
-      })
-    })
-
-    it('has an immutable CID', (done) => {
-      DAGNode.create(Buffer.from('hello world'), (err, node) => {
-        expect(err).to.not.exist()
-
-        try {
-          node.cid = 'foo'
-          throw new Error('Should not be able to update CID')
-        } catch (error) {
-          expect(error.message).to.include("'cid' is immutable")
-          done()
-        }
-      })
-    })
   })
 }

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -272,7 +272,7 @@ module.exports = (repo) => {
             cb()
           })
         },
-        (cb) => toDAGLink(node2, cb),
+        (cb) => toDAGLink(node2.toJSON(), cb),
         (link, cb) => {
           DAGNode.addLink(node1, link, (err, node1b) => {
             expect(err).to.not.exist()

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -14,6 +14,7 @@ const waterfall = require('async/waterfall')
 const dagPB = require('../src')
 const DAGNode = dagPB.DAGNode
 const resolver = dagPB.resolver
+const utils = require('../src/util')
 
 describe('IPLD Format resolver (local)', () => {
   let emptyNodeBlob
@@ -22,18 +23,16 @@ describe('IPLD Format resolver (local)', () => {
 
   const links = [{
     name: '',
-    multihash: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U',
+    cid: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U',
     size: 10
   }, {
     name: 'named link',
-    multihash: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V',
+    cid: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V',
     size: 8
   }]
   const create = (data, links, callback) => waterfall([
     (cb) => DAGNode.create(data, links, cb),
-    (n, cb) => {
-      cb(null, n.serialized)
-    }
+    (n, cb) => utils.serialize(n, cb)
   ], callback)
 
   before((done) => {
@@ -122,7 +121,7 @@ describe('IPLD Format resolver (local)', () => {
       it('links position path Hash', (done) => {
         resolver.resolve(linksNodeBlob, 'Links/1/Hash', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value['/']).to.eql(links[1].multihash)
+          expect(result.value['/']).to.eql(links[1].cid)
           expect(result.remainderPath).to.eql('')
           done()
         })
@@ -149,7 +148,7 @@ describe('IPLD Format resolver (local)', () => {
       it('links by name', (done) => {
         resolver.resolve(linksNodeBlob, 'named link', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value['/']).to.eql(links[1].multihash)
+          expect(result.value['/']).to.eql(links[1].cid)
           expect(result.remainderPath).to.eql('')
           done()
         })


### PR DESCRIPTION
Follows on from https://github.com/ipld/js-ipld/issues/173#issuecomment-434408680

These properties are removed from the DAGNode class.

* `.multihash` is removed because they aren't multihashes any more
* `.cid` is removed to bring dag-pb in line with other ipld types
* `.serialized` is removed because storing data buffers and the serialized form uses too much memory - we can use the utils.serialize method to create the serialized form when we need it, which in this module is just during the tests

`.multihash` has also changed to `.cid` in the output of `DAGLink.toJSON` and `DAGNode.toJSON` because since CIDv1 they are not just multihashes any more; the multihash is contained within the CID.