### PR TITLE
perf: remove unneeded Buffer.from() call during deserialize

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -82,7 +82,7 @@ function deserialize (buffer, callback) {
     return new DAGLink(link.Name, link.Tsize, link.Hash)
   })
 
-  const data = pbn.Data == null ? Buffer.alloc(0) : Buffer.from(pbn.Data)
+  const data = pbn.Data == null ? Buffer.alloc(0) : pbn.Data
 
   setImmediate(() => callback(null, new DAGNode(data, links, buffer.length)))
 }


### PR DESCRIPTION
This Buffer.from() call make Node.js copy and reinitialize a Buffer
object, and it is a minor bottleneck of js-ipfs.

Before:

https://upload.clinicjs.org/public/d577b4af6f5c92adea857561aef4b3590f0fab3c964b00acc06f4093d73ce6dc/52850.clinic-flame.html

After:

https://upload.clinicjs.org/public/4ba0640c671dd4a618e486e9010abe537d82bb4be5d5ca3464c72445c7a22cae/53064.clinic-flame.html
