### PR TITLE
perf: memoize the Name buffer in DAGLink to avoid unneeded allocations

### DIFF
--- a/src/dag-link/index.js
+++ b/src/dag-link/index.js
@@ -13,6 +13,7 @@ class DAGLink {
     //  for now to maintain consistency with go-ipfs pinset
 
     this._name = name || ''
+    this._nameBuf = null
     this._size = size
     this._cid = new CID(cid)
   }
@@ -35,6 +36,18 @@ class DAGLink {
 
   get name () {
     return this._name
+  }
+
+  // Memoize the Buffer representation of name
+  // We need this to sort the links, otherwise
+  // we will reallocate new buffers every time
+  get nameAsBuffer () {
+    if (this._nameBuf !== null) {
+      return this._nameBuf
+    }
+
+    this._nameBuf = Buffer.from(this._name)
+    return this._nameBuf
   }
 
   set name (name) {

--- a/src/dag-node/util.js
+++ b/src/dag-node/util.js
@@ -25,10 +25,7 @@ function cloneLinks (dagNode) {
 }
 
 function linkSort (a, b) {
-  const aBuf = Buffer.from(a.name || '')
-  const bBuf = Buffer.from(b.name || '')
-
-  return aBuf.compare(bBuf)
+  return Buffer.compare(a.nameAsBuffer, b.nameAsBuffer)
 }
 
 /*


### PR DESCRIPTION
Allocating two buffers for every comparison was quite expensive.
This commit replaces Buffer.compare with String.prototype.localeCompare.

Fixes https://github.com/ipld/js-ipld-dag-pb/issues/107
Fixes: #104