### PR TITLE
[WIP] refactor: use CIDv1 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "bs58": "^4.0.1",
-    "cids": "~0.5.4",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "class-is": "^1.1.0",
     "is-ipfs": "~0.4.2",
     "multihashing-async": "~0.5.1",

--- a/src/util.js
+++ b/src/util.js
@@ -21,7 +21,7 @@ exports = module.exports
  *
  * @param {Object} dagNode - Internal representation
  * @param {Object} [options] - Options to create the CID
- * @param {number} [options.version] - CID version number. Defaults to zero if hashAlg == 'sha2-256'; otherwise, 1.
+ * @param {number} [options.version] - CID version number. Defaults to 1.
  * @param {string} [options.hashAlg] - Defaults to hashAlg for the resolver
  * @param {CidCallback} callback - Callback that handles the return value
  * @returns {void}
@@ -33,10 +33,8 @@ function cid (dagNode, options, callback) {
   }
   options = options || {}
   const hashAlg = options.hashAlg || resolver.defaultHashAlg
-  let version = options.version
-  if (typeof version === 'undefined') {
-    version = hashAlg === 'sha2-256' ? 0 : 1
-  }
+  const version = options.version == null ? 1 : options.version
+
   waterfall([
     (cb) => {
       if (Buffer.isBuffer(dagNode)) {

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -416,7 +416,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           expect(cid.multihash).to.exist()
           expect(cid.codec).to.equal('dag-pb')
-          expect(cid.version).to.equal(0)
+          expect(cid.version).to.equal(1)
           const mh = multihash.decode(cid.multihash)
           expect(mh.name).to.equal('sha2-256')
           done()
@@ -532,7 +532,7 @@ module.exports = (repo) => {
 
         dagPB.util.cid(node, (err, cid) => {
           expect(err).to.not.exist()
-          expect(cid.toBaseEncodedString()).to.eql('QmQqy2SiEkKgr2cw5UbQ93TtLKEMsD8TdcWggR8q9JabjX')
+          expect(cid.toBaseEncodedString()).to.eql('bafybeibfhhww5bpsu34qs7nz25wp7ve36mcc5mxd5du26sr45bbnjhpkei')
           done()
         })
       })
@@ -571,7 +571,7 @@ module.exports = (repo) => {
 
         dagPB.util.cid(node, (err, cid) => {
           expect(err).to.not.exist()
-          expect(cid.toBaseEncodedString()).to.eql('QmbSAC58x1tsuPBAoarwGuTQAgghKvdbKSBC8yp5gKCj5M')
+          expect(cid.toBaseEncodedString()).to.eql('bafybeigcsevw74ssldzfwhiijzmg7a35lssfmjkuoj2t5qs5u5aztj47tq')
           done()
         })
       })

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -8,11 +8,13 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 const {
+  DAGNode,
   DAGLink
 } = require('../src')
 const {
   serialize,
-  deserialize
+  deserialize,
+  cid
 } = require('../src/util')
 
 describe('util', () => {
@@ -92,6 +94,18 @@ describe('util', () => {
       expect(result).to.be.an.instanceof(Buffer)
       expect(result).to.be.empty()
       done()
+    })
+  })
+
+  it('should calculate a v0 CID', (done) => {
+    DAGNode.create(Buffer.from('TEST' + Date.now()), (err, node) => {
+      expect(err).to.not.exist()
+
+      cid(node, { version: 0 }, (err, cid) => {
+        expect(err).to.not.exist()
+        expect(cid.version).to.equal(0)
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
BREAKING CHANGE: `util.cid` now defaults to version 1 CIDs and created CIDs are now base32 encoded by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73