### PR TITLE
chore: clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,18 +63,15 @@
   },
   "dependencies": {
     "async": "^2.6.1",
-    "bs58": "^4.0.1",
     "cids": "~0.5.4",
     "class-is": "^1.1.0",
-    "is-ipfs": "~0.6.0",
     "multihashing-async": "~0.5.1",
     "protons": "^1.0.1",
-    "pull-stream": "^3.6.9",
-    "pull-traverse": "^1.0.3",
     "stable": "~0.1.8"
   },
   "devDependencies": {
     "aegir": "^18.2.0",
+    "bs58": "^4.0.1",
     "chai": "^4.1.2",
     "chai-checkmark": "^1.0.1",
     "detect-node": "^2.0.4",
@@ -82,7 +79,6 @@
     "ipfs-block": "~0.8.0",
     "ipfs-block-service": "~0.15.2",
     "ipfs-repo": "~0.26.0",
-    "lodash": "^4.17.11",
     "multihashes": "~0.4.14",
     "ncp": "^2.0.0",
     "rimraf": "^2.6.2"


### PR DESCRIPTION
There are a lot of dependencies that are no longer needed.

Checked via:

dependency-check ./package.json --missing --no-dev
dependency-check ./package.json --unused --no-dev
dependency-check ./package.json --missing ./test/*
dependency-check ./package.json --unused ./test/*