### PR TITLE
feat: new IPLD Format API

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,18 +62,20 @@
     "npm": ">=3.0.0"
   },
   "dependencies": {
-    "async": "^2.6.1",
     "cids": "~0.5.4",
     "class-is": "^1.1.0",
+    "merge-options": "^1.0.1",
+    "multicodec": "~0.5.0",
     "multihashing-async": "~0.5.1",
     "protons": "^1.0.1",
     "stable": "~0.1.8"
   },
   "devDependencies": {
     "aegir": "^18.2.0",
+    "async": "^2.6.2",
     "bs58": "^4.0.1",
     "chai": "^4.1.2",
-    "chai-checkmark": "^1.0.1",
+    "chai-as-promised": "^7.1.1",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
     "ipfs-block": "~0.8.0",

--- a/src/dag-link/index.js
+++ b/src/dag-link/index.js
@@ -3,6 +3,7 @@
 const CID = require('cids')
 const assert = require('assert')
 const withIs = require('class-is')
+const visibility = require('../visibility')
 
 // Link represents an IPFS Merkle DAG Link between Nodes.
 class DAGLink {
@@ -16,25 +17,29 @@ class DAGLink {
     this._nameBuf = null
     this._size = size
     this._cid = new CID(cid)
+
+    // Make sure we have a nice public API that can be used by an IPLD resolver
+    visibility.hidePrivateFields(this)
+    visibility.addEnumerableGetters(this, ['Hash', 'Name', 'Tsize'])
   }
 
   toString () {
-    return `DAGLink <${this._cid.toBaseEncodedString()} - name: "${this.name}", size: ${this.size}>`
+    return `DAGLink <${this._cid.toBaseEncodedString()} - name: "${this.Name}", size: ${this.Tsize}>`
   }
 
   toJSON () {
     if (!this._json) {
       this._json = Object.freeze({
-        name: this.name,
-        size: this.size,
-        cid: this._cid.toBaseEncodedString()
+        name: this.Name,
+        size: this.Tsize,
+        cid: this.Hash.toBaseEncodedString()
       })
     }
 
     return Object.assign({}, this._json)
   }
 
-  get name () {
+  get Name () {
     return this._name
   }
 
@@ -50,23 +55,23 @@ class DAGLink {
     return this._nameBuf
   }
 
-  set name (name) {
+  set Name (name) {
     throw new Error("Can't set property: 'name' is immutable")
   }
 
-  get size () {
+  get Tsize () {
     return this._size
   }
 
-  set size (size) {
+  set Tsize (size) {
     throw new Error("Can't set property: 'size' is immutable")
   }
 
-  get cid () {
+  get Hash () {
     return this._cid
   }
 
-  set cid (cid) {
+  set Hash (cid) {
     throw new Error("Can't set property: 'cid' is immutable")
   }
 }

--- a/src/dag-link/util.js
+++ b/src/dag-link/util.js
@@ -5,7 +5,7 @@ const DAGLink = require('./index')
 function createDagLinkFromB58EncodedHash (link) {
   return new DAGLink(
     link.name ? link.name : link.Name,
-    link.size ? link.size : link.Size,
+    link.size ? link.size : link.Tsize,
     link.hash || link.Hash || link.multihash || link.cid
   )
 }

--- a/src/dag-node/addLink.js
+++ b/src/dag-node/addLink.js
@@ -8,40 +8,30 @@ const DAGLink = require('../dag-link')
 const DAGNode = require('./index')
 const create = require('./create')
 
-function asDAGLink (link, callback) {
+const asDAGLink = async (link) => {
   if (DAGLink.isDAGLink(link)) {
     // It's a DAGLink instance
     // no need to do anything
-
-    return callback(null, link)
+    return link
   }
 
   if (DAGNode.isDAGNode(link)) {
     // It's a DAGNode instance
     // convert to link
-    return toDAGLink(link, {}, callback)
+    return toDAGLink(link, {})
   }
 
   // It's a Object with name, multihash/hash/cid and size
-  try {
-    callback(null, new DAGLink(link.name, link.size, link.multihash || link.hash || link.cid))
-  } catch (err) {
-    return callback(err)
-  }
+  return new DAGLink(link.name, link.size, link.multihash || link.hash || link.cid)
 }
 
-function addLink (node, link, callback) {
+const addLink = async (node, link) => {
   const links = cloneLinks(node)
   const data = cloneData(node)
 
-  asDAGLink(link, (error, link) => {
-    if (error) {
-      return callback(error)
-    }
-
-    links.push(link)
-    create(data, links, callback)
-  })
+  const dagLink = await asDAGLink(link)
+  links.push(dagLink)
+  return create(data, links)
 }
 
 module.exports = addLink

--- a/src/dag-node/addNamedLink.js
+++ b/src/dag-node/addNamedLink.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * Adds a link with its name as property to an object.
+ *
+ * The link won't be added if its name is empty or matches one of the existing
+ * properties.
+ *
+ * @param {Object} object - The object that contains an array of links
+ * @param {string} name - The name of the link to add
+ * @param {numner} position - The position within the array of links
+ */
+const addNamedLink = (object, name, position) => {
+  const skipNames = ['', ...Object.keys(this)]
+  if (skipNames.includes(name)) {
+    return
+  }
+  Object.defineProperty(object, name, {
+    enumerable: true,
+    configurable: true,
+    get: () => object._links[position]
+  })
+}
+
+module.exports = addNamedLink

--- a/src/dag-node/create.js
+++ b/src/dag-node/create.js
@@ -9,36 +9,25 @@ const linkSort = dagNodeUtil.linkSort
 const DAGNode = require('./index.js')
 const DAGLink = require('../dag-link')
 
-function create (data, links, callback) {
-  if (typeof data === 'function') {
-    callback = data
-    data = undefined
-  } else if (typeof data === 'string') {
+const create = async (data, links = []) => {
+  if (typeof data === 'string') {
     data = Buffer.from(data)
-  }
-  if (typeof links === 'function') {
-    callback = links
-    links = []
   }
 
   if (!Buffer.isBuffer(data)) {
-    return callback(new Error('Passed \'data\' is not a buffer or a string!'))
+    throw new Error('Passed \'data\' is not a buffer or a string!')
   }
-
   links = links.map((link) => {
     return DAGLink.isDAGLink(link) ? link : DAGLink.util.createDagLinkFromB58EncodedHash(link)
   })
   links = sort(links, linkSort)
 
-  serialize({
-    data, links
-  }, (err, buffer) => {
-    if (err) {
-      return callback(err)
-    }
-
-    return callback(null, new DAGNode(data, links, buffer.length))
+  const serialized = await serialize({
+    Data: data,
+    Links: links
   })
+
+  return new DAGNode(data, links, serialized.length)
 }
 
 module.exports = create

--- a/src/dag-node/index.js
+++ b/src/dag-node/index.js
@@ -2,6 +2,8 @@
 
 const assert = require('assert')
 const withIs = require('class-is')
+const addNamedLink = require('./addNamedLink')
+const visibility = require('../visibility')
 
 class DAGNode {
   constructor (data, links, serializedSize) {
@@ -10,15 +12,26 @@ class DAGNode {
     }
 
     this._data = data || Buffer.alloc(0)
-    this._links = links || []
+    this._links = links
     this._serializedSize = serializedSize
+
+    // Make sure we have a nice public API that can be used by an IPLD resolver
+    visibility.hidePrivateFields(this)
+    visibility.addEnumerableGetters(this, ['Data', 'Links'])
+
+    // Add getters for existing links by the name of the link
+    // This is how paths are traversed in IPFS. Links with names won't
+    // override existing fields like `data` or `links`.
+    links.forEach((link, position) => {
+      addNamedLink(this, link.Name, position)
+    })
   }
 
   toJSON () {
     if (!this._json) {
       this._json = Object.freeze({
-        data: this.data,
-        links: this.links.map((l) => l.toJSON()),
+        data: this.Data,
+        links: this._links.map((l) => l.toJSON()),
         size: this.size
       })
     }
@@ -27,28 +40,12 @@ class DAGNode {
   }
 
   toString () {
-    return `DAGNode <data: "${this.data.toString('base64')}", links: ${this.links.length}, size: ${this.size}>`
-  }
-
-  get data () {
-    return this._data
-  }
-
-  set data (data) {
-    throw new Error("Can't set property: 'data' is immutable")
-  }
-
-  get links () {
-    return this._links
-  }
-
-  set links (links) {
-    throw new Error("Can't set property: 'links' is immutable")
+    return `DAGNode <data: "${this.Data.toString('base64')}", links: ${this.Links.length}, size: ${this.size}>`
   }
 
   get size () {
     if (this._size === undefined) {
-      this._size = this.links.reduce((sum, l) => sum + l.size, this._serializedSize)
+      this._size = this._links.reduce((sum, l) => sum + l.Tsize, this._serializedSize)
     }
 
     return this._size
@@ -56,6 +53,26 @@ class DAGNode {
 
   set size (size) {
     throw new Error("Can't set property: 'size' is immutable")
+  }
+
+  // Getters for backwards compatible path resolving
+  get Data () {
+    return this._data
+  }
+  set Data (_) {
+    throw new Error("Can't set property: 'Data' is immutable")
+  }
+  get Links () {
+    return this._links.map((link) => {
+      return {
+        Name: link.Name,
+        Tsize: link.Tsize,
+        Hash: link.Hash
+      }
+    })
+  }
+  set Links (_) {
+    throw new Error("Can't set property: 'Links' is immutable")
   }
 }
 

--- a/src/dag-node/rmLink.js
+++ b/src/dag-node/rmLink.js
@@ -6,19 +6,19 @@ const cloneData = dagNodeUtil.cloneData
 const create = require('./create')
 const CID = require('cids')
 
-function rmLink (dagNode, nameOrCid, callback) {
+const rmLink = async (dagNode, nameOrCid) => {
   const data = cloneData(dagNode)
   let links = cloneLinks(dagNode)
 
   if (typeof nameOrCid === 'string') {
-    links = links.filter((link) => link.name !== nameOrCid)
+    links = links.filter((link) => link.Name !== nameOrCid)
   } else if (Buffer.isBuffer(nameOrCid) || CID.isCID(nameOrCid)) {
-    links = links.filter((link) => !link.cid.equals(nameOrCid))
+    links = links.filter((link) => !link.Hash.equals(nameOrCid))
   } else {
-    return callback(new Error('second arg needs to be a name or CID'), null)
+    throw new Error('second arg needs to be a name or CID')
   }
 
-  create(data, links, callback)
+  return create(data, links)
 }
 
 module.exports = rmLink

--- a/src/dag-node/util.js
+++ b/src/dag-node/util.js
@@ -2,7 +2,8 @@
 
 const DAGLink = require('./../dag-link')
 const {
-  cid
+  cid,
+  serialize
 } = require('../util')
 
 exports = module.exports
@@ -10,9 +11,9 @@ exports = module.exports
 function cloneData (dagNode) {
   let data
 
-  if (dagNode.data && dagNode.data.length > 0) {
-    data = Buffer.alloc(dagNode.data.length)
-    dagNode.data.copy(data)
+  if (dagNode.Data && dagNode.Data.length > 0) {
+    data = Buffer.alloc(dagNode.Data.length)
+    dagNode.Data.copy(data)
   } else {
     data = Buffer.alloc(0)
   }
@@ -21,7 +22,7 @@ function cloneData (dagNode) {
 }
 
 function cloneLinks (dagNode) {
-  return dagNode.links.slice()
+  return dagNode.Links.slice()
 }
 
 function linkSort (a, b) {
@@ -31,19 +32,10 @@ function linkSort (a, b) {
 /*
  * toDAGLink converts a DAGNode to a DAGLink
  */
-function toDAGLink (node, options, callback) {
-  if (typeof options === 'function') {
-    callback = options
-    options = {}
-  }
-
-  cid(node, options, (error, cid) => {
-    if (error) {
-      return callback(error)
-    }
-
-    callback(null, new DAGLink(options.name || '', node.size, cid))
-  })
+const toDAGLink = async (node, options = {}) => {
+  const serialized = await serialize(node)
+  const nodeCid = await cid(serialized)
+  return new DAGLink(options.name || '', serialized.length, nodeCid)
 }
 
 exports.cloneData = cloneData

--- a/src/index.js
+++ b/src/index.js
@@ -9,3 +9,5 @@ exports.DAGLink = require('./dag-link')
  */
 exports.resolver = require('./resolver')
 exports.util = require('./util')
+exports.format = exports.util.format
+exports.defaultHashAlg = exports.util.defaultHashAlg

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,164 +1,58 @@
 'use strict'
 
-const waterfall = require('async/waterfall')
 const CID = require('cids')
 
 const util = require('./util')
 
 exports = module.exports
-exports.multicodec = 'dag-pb'
-exports.defaultHashAlg = 'sha2-256'
 
 /*
  * resolve: receives a path and a binary blob and returns the value on path,
  * throw if not possible. `binaryBlob` is the ProtocolBuffer encoded data.
  */
-exports.resolve = (binaryBlob, path, callback) => {
-  waterfall([
-    (cb) => util.deserialize(binaryBlob, cb),
-    (node, cb) => {
-      // Return the deserialized block if no path is given
-      if (!path) {
-        return callback(null, {
-          value: node,
-          remainderPath: ''
-        })
-      }
+exports.resolve = async (binaryBlob, path) => {
+  let node = await util.deserialize(binaryBlob)
 
-      const split = path.split('/')
+  const parts = path.split('/').filter((x) => x)
+  while (parts.length) {
+    const key = parts.shift()
+    if (node[key] === undefined) {
+      throw new Error(`Object has no property '${key}'`)
+    }
 
-      if (split[0] === 'Links') {
-        let remainderPath = ''
-
-        // all links
-        if (!split[1]) {
-          return cb(null, {
-            value: node.links.map((l) => l.toJSON()),
-            remainderPath: ''
-          })
-        }
-
-        // select one link
-
-        const values = {}
-
-        // populate both index number and name to enable both cases
-        // for the resolver
-        node.links.forEach((l, i) => {
-          const link = l.toJSON()
-          values[i] = values[link.name] = {
-            cid: link.cid,
-            name: link.name,
-            size: link.size
-          }
-        })
-
-        let value = values[split[1]]
-
-        // if remainderPath exists, value needs to be CID
-        if (split[2] === 'Hash') {
-          value = { '/': value.cid }
-        } else if (split[2] === 'Tsize') {
-          value = value.size
-        } else if (split[2] === 'Name') {
-          value = value.name
-        }
-
-        remainderPath = split.slice(3).join('/')
-
-        cb(null, { value: value, remainderPath: remainderPath })
-      } else if (split[0] === 'Data') {
-        cb(null, { value: node.data, remainderPath: '' })
-      } else {
-        // If split[0] is not 'Data' or 'Links' then we might be trying to refer
-        // to a named link from the Links array. This is because go-ipfs and
-        // js-ipfs have historically supported the ability to do
-        // `ipfs dag get CID/a` where a is a named link in a dag-pb.
-        const values = {}
-
-        node.links.forEach((l, i) => {
-          const link = l.toJSON()
-          values[link.name] = {
-            cid: link.cid,
-            name: link.name,
-            size: link.size
-          }
-        })
-
-        const value = values[split[0]]
-
-        if (value) {
-          return cb(null, {
-            value: { '/': value.cid },
-            remainderPath: split.slice(1).join('/')
-          })
-        }
-
-        cb(new Error('path not available'))
+    node = node[key]
+    if (CID.isCID(node)) {
+      return {
+        value: node,
+        remainderPath: parts.join('/')
       }
     }
-  ], callback)
+  }
+
+  return {
+    value: node,
+    remainderPath: ''
+  }
+}
+
+const traverse = function * (node, path) {
+  // Traverse only objects and arrays
+  if (Buffer.isBuffer(node) || CID.isCID(node) || typeof node === 'string') {
+    return
+  }
+  for (const item of Object.keys(node)) {
+    const nextpath = path === undefined ? item : path + '/' + item
+    yield nextpath
+    yield * traverse(node[item], nextpath)
+  }
 }
 
 /*
  * tree: returns a flattened array with paths: values of the project. options
  * is an object that can carry several options (i.e. nestness)
  */
-exports.tree = (binaryBlob, options, callback) => {
-  if (typeof options === 'function') {
-    callback = options
-    options = {}
-  }
+exports.tree = async function * (binaryBlob) {
+  const node = await util.deserialize(binaryBlob)
 
-  options = options || {}
-
-  util.deserialize(binaryBlob, (err, node) => {
-    if (err) {
-      return callback(err)
-    }
-
-    const paths = []
-
-    paths.push('Links')
-
-    node.links.forEach((link, i) => {
-      paths.push(`Links/${i}/Name`)
-      paths.push(`Links/${i}/Tsize`)
-      paths.push(`Links/${i}/Hash`)
-    })
-
-    paths.push('Data')
-
-    callback(null, paths)
-  })
-}
-
-/*
- * isLink: returns the Link if a given path in a binary blob is a Link,
- * false otherwise
- */
-exports.isLink = (binaryBlob, path, callback) => {
-  exports.resolve(binaryBlob, path, (err, result) => {
-    if (err) {
-      return callback(err)
-    }
-
-    if (result.remainderPath.length > 0) {
-      return callback(new Error('path out of scope'))
-    }
-
-    if (typeof result.value === 'object' && result.value['/']) {
-      let valid
-      try {
-        valid = CID.isCID(new CID(result.value['/']))
-      } catch (err) {
-        valid = false
-      }
-      if (valid) {
-        return callback(null, result.value)
-      }
-    }
-
-    callback(null, false)
-  })
+  yield * traverse(node)
 }

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * Make certain getters enumnerable
+ *
+ * This can be used to add additional getters that are enumerable and hence
+ * show up on an `Object.keys()` call.
+ *
+ * @param {Object} object - The object it should be applied to
+ * @param {Array.<String>} fields - The fields that should be made enumnerable
+ */
+const addEnumerableGetters = (object, fields) => {
+  for (const field of fields) {
+    let prop
+    let proto = object
+    // Walk up the proottype chain until a property with the given name is
+    // found
+    while (prop === undefined) {
+      proto = Object.getPrototypeOf(proto)
+      if (proto === null) {
+        throw new Error(`no getter named '${field}' found`)
+      }
+      prop = Object.getOwnPropertyDescriptor(proto, field)
+    }
+
+    // There is a property with the correct name, but it's not a getter
+    if (prop.get === undefined) {
+      throw new Error(`no getter named '${field}' found`)
+    }
+    Object.defineProperty(object, field, {
+      enumerable: true,
+      get: prop.get
+    })
+  }
+}
+
+/**
+ * Makes all properties with a leading underscore non-enumerable.
+ *
+ * @param {Object} object - The object it should be applied to
+ */
+const hidePrivateFields = (object) => {
+  for (const key in object) {
+    if (key[0] === '_') {
+      Object.defineProperty(object, key, { enumerable: false })
+    }
+  }
+}
+
+module.exports = {
+  addEnumerableGetters,
+  hidePrivateFields
+}

--- a/test/dag-link-test.js
+++ b/test/dag-link-test.js
@@ -14,19 +14,19 @@ module.exports = (repo) => {
       it('string', () => {
         const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
 
-        expect(link.cid.buffer.toString('hex'))
+        expect(link.Hash.buffer.toString('hex'))
           .to.equal('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43')
       })
 
       it('empty string', () => {
         const link = new DAGLink('', 4, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
-        expect(link.name).to.be.eql('')
+        expect(link.Name).to.be.eql('')
       })
 
       it('create with multihash as a multihash Buffer', () => {
         const link = new DAGLink('hello', 3, Buffer.from('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43', 'hex'))
 
-        expect(new CID(link.cid).toBaseEncodedString())
+        expect(new CID(link.Hash).toBaseEncodedString())
           .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
       })
 
@@ -57,17 +57,17 @@ module.exports = (repo) => {
     it('exposes a CID', () => {
       const cid = 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'
       const link = new DAGLink('hello', 3, cid)
-      expect(link.cid.toBaseEncodedString()).to.equal(cid)
+      expect(link.Hash.toBaseEncodedString()).to.equal(cid)
     })
 
     it('has an immutable CID', () => {
       const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
 
       try {
-        link.cid = 'foo'
+        link.Hash = 'foo'
         throw new Error('Should not be able to update CID')
       } catch (error) {
-        expect(error.message).to.include("'cid' is immutable")
+        expect(error.message).to.include('Cannot set property Hash of')
       }
     })
   })

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -1,23 +1,20 @@
 /* eslint-env mocha */
-/* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
 const chai = require('chai')
+const chaiAsProised = require('chai-as-promised')
 const dirtyChai = require('dirty-chai')
-const checkmark = require('chai-checkmark')
 const expect = chai.expect
+chai.use(chaiAsProised)
 chai.use(dirtyChai)
-chai.use(checkmark)
 
 const dagPB = require('../src')
 const DAGLink = dagPB.DAGLink
 const DAGNode = dagPB.DAGNode
 const toDAGLink = require('../src/dag-node/util').toDAGLink
-const util = dagPB.util
-const series = require('async/series')
-const waterfall = require('async/waterfall')
 const isNode = require('detect-node')
 const multihash = require('multihashes')
+const multicodec = require('multicodec')
 
 const BlockService = require('ipfs-block-service')
 const Block = require('ipfs-block')
@@ -32,459 +29,261 @@ module.exports = (repo) => {
   const bs = new BlockService(repo)
 
   describe('DAGNode', () => {
-    it('create a node', (done) => {
-      expect(7).checks(done)
+    it('create a node', async () => {
       const data = Buffer.from('some data')
 
-      DAGNode.create(data, (err, node) => {
-        expect(err).to.not.exist.mark()
-        expect(node.data.length).to.be.above(0).mark()
-        expect(Buffer.isBuffer(node.data)).to.be.true.mark()
-        expect(node.size).to.be.above(0).mark()
+      const node = await DAGNode.create(data)
+      expect(node.Data.length).to.be.above(0)
+      expect(Buffer.isBuffer(node.Data)).to.be.true()
+      expect(node.size).to.be.above(0)
 
-        dagPB.util.serialize(node, (err, serialized) => {
-          expect(err).to.not.exist.mark()
-
-          dagPB.util.deserialize(serialized, (err, deserialized) => {
-            expect(err).to.not.exist.mark()
-            expect(node.data).to.eql(deserialized.data).mark()
-          })
-        })
-      })
+      const serialized = await dagPB.util.serialize(node)
+      const deserialized = await dagPB.util.deserialize(serialized)
+      expect(node.Data).to.eql(deserialized.Data)
     })
 
-    it('create a node with string data', (done) => {
-      expect(7).checks(done)
+    it('create a node with string data', async () => {
       const data = 'some data'
 
-      DAGNode.create(data, (err, node) => {
-        expect(err).to.not.exist.mark()
-        expect(node.data.length).to.be.above(0).mark()
-        expect(Buffer.isBuffer(node.data)).to.be.true.mark()
-        expect(node.size).to.be.above(0).mark()
+      const node = await DAGNode.create(data)
+      expect(node.Data.length).to.be.above(0)
+      expect(Buffer.isBuffer(node.Data)).to.be.true()
+      expect(node.size).to.be.above(0)
 
-        dagPB.util.serialize(node, (err, serialized) => {
-          expect(err).to.not.exist.mark()
+      const serialized = await dagPB.util.serialize(node)
 
-          dagPB.util.deserialize(serialized, (err, deserialized) => {
-            expect(err).to.not.exist.mark()
-            expect(node.data).to.eql(deserialized.data).mark()
-          })
-        })
-      })
+      const deserialized = await dagPB.util.deserialize(serialized)
+      expect(node.Data).to.eql(deserialized.Data)
     })
 
-    it('create a node with links', (done) => {
+    it('create a node with links', async () => {
       const l1 = [{
         Name: 'some other link',
-        Hash: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V',
-        Size: 8
+        Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V'),
+        Tsize: 8
       }, {
         Name: 'some link',
-        Hash: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U',
-        Size: 10
+        Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'),
+        Tsize: 10
       }]
 
-      let node1
-      let node2
       const someData = Buffer.from('some data')
 
-      series([
-        (cb) => {
-          DAGNode.create(someData, l1, (err, node) => {
-            expect(err).to.not.exist()
-            node1 = node
-            cb()
-          })
-        },
-        (cb) => {
-          const l2 = l1.map((l) => {
-            return new DAGLink(l.Name, l.Size, l.Hash)
-          })
-
-          DAGNode.create(someData, l2, (err, node) => {
-            expect(err).to.not.exist()
-            node2 = node
-            expect(node2.links).to.eql([l2[1], l2[0]])
-            cb()
-          })
-        }
-      ], (err) => {
-        expect(err).to.not.exist()
-        expect(node1.toJSON()).to.eql(node2.toJSON())
-
-        // check sorting
-        expect(node1.links.map((l) => l.name)).to.be.eql([
-          'some link',
-          'some other link'
-        ])
-        done()
+      const node1 = await DAGNode.create(someData, l1)
+      const l2 = l1.map((l) => {
+        return new DAGLink(l.Name, l.Tsize, l.Hash)
       })
+
+      const node2 = await DAGNode.create(someData, l2)
+      expect(node2.Links).to.eql([l1[1], l1[0]])
+      expect(node1.toJSON()).to.eql(node2.toJSON())
+
+      // check sorting
+      expect(node1.Links.map((l) => l.Name)).to.be.eql([
+        'some link',
+        'some other link'
+      ])
     })
 
-    it('create with empty link name', (done) => {
-      DAGNode.create(Buffer.from('hello'), [
+    it('create with empty link name', async () => {
+      const node = await DAGNode.create(Buffer.from('hello'), [
         new DAGLink('', 10, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
-      ], (err, node) => {
-        expect(err).to.not.exist()
-        expect(node.links[0].name).to.be.eql('')
-        done()
-      })
+      ])
+      expect(node.Links[0].Name).to.be.eql('')
     })
 
-    it('create with undefined link name', (done) => {
-      waterfall([
-        (cb) => DAGNode.create(Buffer.from('hello'), [
-          new DAGLink(undefined, 10, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
-        ], cb),
-        (node, cb) => {
-          expect(node.links[0].name).to.be.eql('')
-
-          waterfall([
-            (cb) => dagPB.util.serialize(node, cb),
-            (buffer, cb) => dagPB.util.deserialize(buffer, cb),
-            (deserialized, cb) => {
-              Object.getOwnPropertyNames(node).forEach(key => {
-                expect(node[key]).to.deep.equal(deserialized[key])
-              })
-
-              cb()
-            }
-          ], cb)
-        }
-      ], done)
+    it('create with undefined link name', async () => {
+      const node = await DAGNode.create(Buffer.from('hello'), [
+        new DAGLink(undefined, 10, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+      ])
+      expect(node.Links[0].Name).to.be.eql('')
+      const serialized = await dagPB.util.serialize(node)
+      const deserialized = await dagPB.util.deserialize(serialized)
+      for (const key of Object.keys(node)) {
+        expect(node[key]).to.deep.equal(deserialized[key])
+      }
     })
 
-    it('create an empty node', (done) => {
+    it('create an empty node', async () => {
       // this node is not in the repo as we don't copy node data to the browser
-      expect(7).checks(done)
+      const node = await DAGNode.create(Buffer.alloc(0))
+      expect(node.Data.length).to.be.equal(0)
+      expect(Buffer.isBuffer(node.Data)).to.be.true()
+      expect(node.size).to.be.equal(0)
 
-      DAGNode.create(Buffer.alloc(0), (err, node) => {
-        expect(err).to.not.exist.mark()
-        expect(node.data.length).to.be.equal(0).mark()
-        expect(Buffer.isBuffer(node.data)).to.be.true.mark()
-        expect(node.size).to.be.equal(0).mark()
-
-        dagPB.util.serialize(node, (err, serialized) => {
-          expect(err).to.not.exist.mark()
-
-          dagPB.util.deserialize(serialized, (err, deserialized) => {
-            expect(err).to.not.exist.mark()
-            expect(node.data).to.eql(deserialized.data).mark()
-          })
-        })
-      })
+      const serialized = await dagPB.util.serialize(node)
+      const deserialized = await dagPB.util.deserialize(serialized)
+      expect(node.Data).to.eql(deserialized.Data)
     })
 
-    it('fail to create a node with other data types', (done) => {
-      DAGNode.create({}, (err, node) => {
-        expect(err).to.exist()
-        expect(node).to.not.exist()
-        DAGNode.create([], (err, node) => {
-          expect(err).to.exist()
-          expect(node).to.not.exist()
-          done()
-        })
-      })
+    it('fail to create a node with other data types', async () => {
+      await expect(DAGNode.create({})).to.be.rejectedWith(
+        'Passed \'data\' is not a buffer or a string!'
+      )
+      await expect(DAGNode.create([])).to.be.rejectedWith(
+        'Passed \'data\' is not a buffer or a string!'
+      )
     })
 
-    it('addLink by DAGNode', (done) => {
-      let node1
-      let node2
-
-      series([
-        (cb) => {
-          DAGNode.create(Buffer.from('1'), (err, node) => {
-            expect(err).to.not.exist()
-            node1 = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.create(Buffer.from('2'), (err, node) => {
-            expect(err).to.not.exist()
-            node2 = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.addLink(node1, node2, (err, node1b) => {
-            expect(err).to.not.exist()
-            expect(node1b.links.length).to.equal(1)
-            expect(node1b.links[0].size)
-              .to.eql(node2.size)
-            expect(node1b.links[0].name).to.be.eql('')
-            cb()
-          })
-        }
-      ], done)
+    it('addLink by DAGNode', async () => {
+      const node1a = await DAGNode.create(Buffer.from('1'))
+      const node2 = await DAGNode.create(Buffer.from('2'))
+      const node1b = await DAGNode.addLink(node1a, node2)
+      expect(node1b.Links.length).to.equal(1)
+      expect(node1b.Links[0].Tsize).to.eql(node2.size)
+      expect(node1b.Links[0].Name).to.be.eql('')
     })
 
-    it('addLink by DAGLink', (done) => {
-      let node1
-      let node2
-
-      waterfall([
-        (cb) => {
-          DAGNode.create(Buffer.from('1'), (err, node) => {
-            expect(err).to.not.exist()
-            node1 = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.create(Buffer.from('2'), (err, node) => {
-            expect(err).to.not.exist()
-            node2 = node
-            cb()
-          })
-        },
-        (cb) => toDAGLink(node2, cb),
-        (link, cb) => {
-          DAGNode.addLink(node1, link, (err, node1b) => {
-            expect(err).to.not.exist()
-            expect(node1b.links.length).to.equal(1)
-            expect(node1b.links[0].size)
-              .to.eql(node2.size)
-            expect(node1b.links[0].name).to.be.eql('')
-            cb()
-          })
-        }
-      ], done)
+    it('addLink by DAGLink', async () => {
+      const node1a = await DAGNode.create(Buffer.from('1'))
+      const node2 = await DAGNode.create(Buffer.from('2'))
+      const link = await toDAGLink(node2)
+      const node1b = await DAGNode.addLink(node1a, link)
+      expect(node1b.Links.length).to.equal(1)
+      expect(node1b.Links[0].Tsize).to.eql(node2.size)
+      expect(node1b.Links[0].Name).to.be.eql('')
     })
 
-    it('addLink by object', (done) => {
-      let node1
-      let node2
-
-      waterfall([
-        (cb) => {
-          DAGNode.create(Buffer.from('1'), (err, node) => {
-            expect(err).to.not.exist()
-            node1 = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.create(Buffer.from('2'), (err, node) => {
-            expect(err).to.not.exist()
-            node2 = node
-            cb()
-          })
-        },
-        (cb) => toDAGLink(node2, cb),
-        (link, cb) => {
-          const linkObject = link.toJSON()
-          DAGNode.addLink(node1, linkObject, (err, node1b) => {
-            expect(err).to.not.exist()
-            expect(node1b.links.length).to.equal(1)
-            expect(node1b.links[0].size)
-              .to.eql(node2.size)
-            expect(node1b.links[0].name).to.be.eql('')
-            cb()
-          })
-        }
-      ], done)
+    it('addLink by object', async () => {
+      const node1a = await DAGNode.create(Buffer.from('1'))
+      const node2 = await DAGNode.create(Buffer.from('2'))
+      const link = await toDAGLink(node2)
+      const linkObject = link.toJSON()
+      const node1b = await DAGNode.addLink(node1a, linkObject)
+      expect(node1b.Links.length).to.equal(1)
+      expect(node1b.Links[0].Tsize).to.eql(node2.size)
+      expect(node1b.Links[0].Name).to.be.eql('')
     })
 
-    it('addLink - add several links', (done) => {
-      let node1a
-      let node1b
-      let node1c
-
-      series([
-        (cb) => {
-          DAGNode.create(Buffer.from('1'), (err, node) => {
-            expect(err).to.not.exist()
-            node1a = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.create(Buffer.from('2'), (err, node) => {
-            expect(err).to.not.exist()
-            DAGNode.addLink(node1a, node, (err, node) => {
-              expect(err).to.not.exist()
-              node1b = node
-              cb()
-            })
-          })
-        },
-        (cb) => {
-          DAGNode.create(Buffer.from('3'), (err, node) => {
-            expect(err).to.not.exist()
-            DAGNode.addLink(node1b, node, (err, node) => {
-              expect(err).to.not.exist()
-              node1c = node
-              cb()
-            })
-          })
-        },
-        (cb) => {
-          expect(node1a.links.length).to.equal(0)
-          expect(node1b.links.length).to.equal(1)
-          expect(node1c.links.length).to.equal(2)
-          cb()
-        }
-      ], done)
+    it('addLink by name', async () => {
+      const node1a = await DAGNode.create(Buffer.from('1'))
+      const node2 = await DAGNode.create(Buffer.from('2'))
+      const link = await toDAGLink(node2, { name: 'banana' })
+      expect(Object.keys(node1a)).to.not.include('banana')
+      const node1b = await DAGNode.addLink(node1a, link)
+      expect(node1b.Links.length).to.equal(1)
+      expect(node1b.Links[0].Tsize).to.eql(node2.size)
+      expect(node1b.Links[0].Name).to.eql('banana')
+      expect(Object.keys(node1b)).to.include('banana')
     })
 
-    it('rmLink by name', (done) => {
-      let node1a
-      let node1b
-      let node2
+    it('addLink - add several links', async () => {
+      const node1a = await DAGNode.create(Buffer.from('1'))
+      expect(node1a.Links.length).to.equal(0)
 
-      waterfall([
-        (cb) => {
-          DAGNode.create(Buffer.from('1'), (err, node) => {
-            expect(err).to.not.exist()
-            node1a = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.create(Buffer.from('2'), (err, node) => {
-            expect(err).to.not.exist()
-            node2 = node
-            cb()
-          })
-        },
-        (cb) => toDAGLink(node2, {
-          name: 'banana'
-        }, cb),
-        (link, cb) => {
-          DAGNode.addLink(node1a, link, (err, node) => {
-            expect(err).to.not.exist()
-            node1b = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.rmLink(node1b, 'banana', (err, node) => {
-            expect(err).to.not.exist()
-            expect(node1a.toJSON()).to.eql(node.toJSON())
-            cb()
-          })
-        }
-      ], done)
+      const node2 = await DAGNode.create(Buffer.from('2'))
+      const node1b = await DAGNode.addLink(node1a, node2)
+      expect(node1b.Links.length).to.equal(1)
+
+      const node3 = await DAGNode.create(Buffer.from('3'))
+      const node1c = await DAGNode.addLink(node1b, node3)
+      expect(node1c.Links.length).to.equal(2)
     })
 
-    it('rmLink by hash', (done) => {
-      let node1a
-      let node1b
-      let node2
+    it('rmLink by name', async () => {
+      const node1a = await DAGNode.create(Buffer.from('1'))
+      expect(node1a.Links.length).to.eql(0)
+      const withoutLink = node1a.toJSON()
 
-      waterfall([
-        (cb) => {
-          DAGNode.create(Buffer.from('1'), (err, node) => {
-            expect(err).to.not.exist()
-            node1a = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.create(Buffer.from('2'), (err, node) => {
-            expect(err).to.not.exist()
-            node2 = node
-            cb()
-          })
-        },
-        (cb) => toDAGLink(node2, {
-          name: 'banana'
-        }, cb),
-        (link, cb) => {
-          DAGNode.addLink(node1a, link, (err, node) => {
-            expect(err).to.not.exist()
-            node1b = node
-            cb()
-          })
-        },
-        (cb) => {
-          DAGNode.rmLink(node1b, node1b.links[0].cid, (err, node) => {
-            expect(err).to.not.exist()
-            expect(node1a.toJSON()).to.eql(node.toJSON())
-            cb()
-          })
-        }
-      ], done)
+      const node2 = await DAGNode.create(Buffer.from('2'))
+      const link = await toDAGLink(node2, { name: 'banana' })
+
+      const node1b = await DAGNode.addLink(node1a, link)
+      expect(node1b.Links.length).to.eql(1)
+      expect(Object.keys(node1b)).to.include('banana')
+      const node1c = await DAGNode.rmLink(node1b, 'banana')
+      expect(Object.keys(node1c)).to.not.include('banana')
+      expect(node1c.Links.length).to.eql(0)
+      expect(node1c.toJSON()).to.eql(withoutLink)
     })
 
-    it('get node CID', (done) => {
-      DAGNode.create(Buffer.from('some data'), (err, node) => {
-        expect(err).to.not.exist()
-        util.cid(node, (err, cid) => {
+    it('rmLink by hash', async () => {
+      const node1a = await DAGNode.create(Buffer.from('1'))
+      expect(node1a.Links.length).to.eql(0)
+      const withoutLink = node1a.toJSON()
+
+      const node2 = await DAGNode.create(Buffer.from('2'))
+      const link = await toDAGLink(node2, { name: 'banana' })
+
+      const node1b = await DAGNode.addLink(node1a, link)
+      expect(node1b.Links.length).to.eql(1)
+      expect(Object.keys(node1b)).to.include('banana')
+      const node1c = await DAGNode.rmLink(node1b, node1b.Links[0].Hash)
+      expect(Object.keys(node1c)).to.not.include('banana')
+      expect(node1c.Links.length).to.eql(0)
+      expect(node1c.toJSON()).to.eql(withoutLink)
+    })
+
+    it('get node CID', async () => {
+      const node = await DAGNode.create(Buffer.from('some data'))
+      const serialized = await dagPB.util.serialize(node)
+      const cid = await dagPB.util.cid(serialized)
+      expect(cid.multihash).to.exist()
+      expect(cid.codec).to.equal('dag-pb')
+      expect(cid.version).to.equal(1)
+      const mh = multihash.decode(cid.multihash)
+      expect(mh.name).to.equal('sha2-256')
+    })
+
+    it('get node CID with version', async () => {
+      const node = await DAGNode.create(Buffer.from('some data'))
+      const serialized = await dagPB.util.serialize(node)
+      const cid = await dagPB.util.cid(serialized, { cidVersion: 0 })
+      expect(cid.multihash).to.exist()
+      expect(cid.codec).to.equal('dag-pb')
+      expect(cid.version).to.equal(0)
+      const mh = multihash.decode(cid.multihash)
+      expect(mh.name).to.equal('sha2-256')
+    })
+
+    it('get node CID with hashAlg', async () => {
+      const node = await DAGNode.create(Buffer.from('some data'))
+      const serialized = await dagPB.util.serialize(node)
+      const cid = await dagPB.util.cid(serialized, { hashAlg: multicodec.SHA2_512 })
+      expect(cid.multihash).to.exist()
+      expect(cid.codec).to.equal('dag-pb')
+      expect(cid.version).to.equal(1)
+      const mh = multihash.decode(cid.multihash)
+      expect(mh.name).to.equal('sha2-512')
+    })
+
+    it('marshal a node and store it with block-service', async () => {
+      const node = await DAGNode.create(Buffer.from('some data'))
+      const serialized = await dagPB.util.serialize(node)
+      const cid = await dagPB.util.cid(serialized)
+      const block = new Block(Buffer.from(serialized), cid)
+      return new Promise((resolve) => {
+        bs.put(block, (err) => {
           expect(err).to.not.exist()
-          expect(cid.multihash).to.exist()
-          expect(cid.codec).to.equal('dag-pb')
-          expect(cid.version).to.equal(0)
-          const mh = multihash.decode(cid.multihash)
-          expect(mh.name).to.equal('sha2-256')
-          done()
-        })
-      })
-    })
-
-    it('get node CID with hashAlg', (done) => {
-      DAGNode.create(Buffer.from('some data'), (err, node) => {
-        expect(err).to.not.exist()
-        util.cid(node, { hashAlg: 'sha2-512' }, (err, cid) => {
-          expect(err).to.not.exist()
-          expect(cid.multihash).to.exist()
-          expect(cid.codec).to.equal('dag-pb')
-          expect(cid.version).to.equal(1)
-          const mh = multihash.decode(cid.multihash)
-          expect(mh.name).to.equal('sha2-512')
-          done()
-        })
-      })
-    })
-
-    it('marshal a node and store it with block-service', (done) => {
-      DAGNode.create(Buffer.from('some data'), (err, node) => {
-        expect(err).to.not.exist()
-        let block
-
-        waterfall([
-          (cb) => dagPB.util.serialize(node, cb),
-          (s, cb) => dagPB.util.cid(s, (err, cid) => {
-            cb(err, {
-              buffer: s,
-              cid: cid
-            })
-          }),
-          ({ buffer, cid }, cb) => {
-            block = new Block(buffer, cid)
-            bs.put(block, cb)
-          },
-          (cb) => bs.get(block.cid, cb),
-          (retrievedBlock, cb) => {
+          bs.get(block.cid, (err, retrievedBlock) => {
+            expect(err).to.not.exist()
             expect(retrievedBlock).to.eql(block)
-            cb()
-          }
-        ], done)
+            resolve()
+          })
+        })
       })
     })
 
-    it('deserialize go-ipfs block from ipldResolver', (done) => {
+    it('deserialize go-ipfs block from ipldResolver', async () => {
       if (!isNode) {
-        return done()
+        return
       }
 
       const cidStr = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
       const cid = new CID(cidStr)
 
-      bs.get(cid, (err, block) => {
-        expect(err).to.not.exist()
-        dagPB.util.deserialize(block.data, (err, node) => {
+      return new Promise((resolve) => {
+        bs.get(cid, async (err, block) => {
           expect(err).to.not.exist()
-          expect(node.data).to.exist()
-          expect(node.links.length).to.equal(6)
-          done()
+          const node = await dagPB.util.deserialize(block.data)
+          expect(node.Data).to.exist()
+          expect(node.Links.length).to.equal(6)
+          resolve()
         })
       })
     })
 
-    it('deserialize go-ipfs block with unnamed links', (done) => {
+    it('deserialize go-ipfs block with unnamed links', async () => {
       const buf = testBlockUnnamedLinks
 
       const expectedLinks = [
@@ -525,20 +324,16 @@ module.exports = (repo) => {
         }
       ]
 
-      dagPB.util.deserialize(buf, (err, node) => {
-        expect(err).to.not.exist()
-        const nodeJSON = node.toJSON()
-        expect(nodeJSON.links).to.eql(expectedLinks)
+      const node = await dagPB.util.deserialize(buf)
+      const nodeJSON = node.toJSON()
+      expect(nodeJSON.links).to.eql(expectedLinks)
 
-        dagPB.util.cid(node, (err, cid) => {
-          expect(err).to.not.exist()
-          expect(cid.toBaseEncodedString()).to.eql('QmQqy2SiEkKgr2cw5UbQ93TtLKEMsD8TdcWggR8q9JabjX')
-          done()
-        })
-      })
+      const cid = await dagPB.util.cid(buf, { cidVersion: 0 })
+      expect(cid.toBaseEncodedString()).to.eql(
+        'QmQqy2SiEkKgr2cw5UbQ93TtLKEMsD8TdcWggR8q9JabjX')
     })
 
-    it('deserialize go-ipfs block with named links', (done) => {
+    it('deserialize go-ipfs block with named links', async () => {
       const buf = testBlockNamedLinks
 
       const expectedLinks = [
@@ -564,41 +359,31 @@ module.exports = (repo) => {
         }
       ]
 
-      dagPB.util.deserialize(buf, (err, node) => {
-        expect(err).to.not.exist()
-        const nodeJSON = node.toJSON()
-        expect(nodeJSON.links).to.eql(expectedLinks)
+      const node = await dagPB.util.deserialize(buf)
+      const nodeJSON = node.toJSON()
+      expect(nodeJSON.links).to.eql(expectedLinks)
 
-        dagPB.util.cid(node, (err, cid) => {
-          expect(err).to.not.exist()
-          expect(cid.toBaseEncodedString()).to.eql('QmbSAC58x1tsuPBAoarwGuTQAgghKvdbKSBC8yp5gKCj5M')
-          done()
-        })
-      })
+      const cid = await dagPB.util.cid(buf, { cidVersion: 0 })
+      expect(cid.toBaseEncodedString()).to.eql(
+        'QmbSAC58x1tsuPBAoarwGuTQAgghKvdbKSBC8yp5gKCj5M')
     })
 
-    it('dagNode.toJSON with empty Node', (done) => {
-      DAGNode.create(Buffer.alloc(0), (err, node) => {
-        expect(err).to.not.exist()
-        expect(node.toJSON().data).to.eql(Buffer.alloc(0))
-        expect(node.toJSON().links).to.eql([])
-        expect(node.toJSON().size).to.exist()
-        done()
-      })
+    it('dagNode.toJSON with empty Node', async () => {
+      const node = await DAGNode.create(Buffer.alloc(0))
+      expect(node.toJSON().data).to.eql(Buffer.alloc(0))
+      expect(node.toJSON().links).to.eql([])
+      expect(node.toJSON().size).to.exist()
     })
 
-    it('dagNode.toJSON with data no links', (done) => {
+    it('dagNode.toJSON with data no links', async () => {
       const data = Buffer.from('La cucaracha')
-      DAGNode.create(data, (err, node) => {
-        expect(err).to.not.exist()
-        expect(node.toJSON().data).to.eql(data)
-        expect(node.toJSON().links).to.eql([])
-        expect(node.toJSON().size).to.exist()
-        done()
-      })
+      const node = await DAGNode.create(data)
+      expect(node.toJSON().data).to.eql(data)
+      expect(node.toJSON().links).to.eql([])
+      expect(node.toJSON().size).to.exist()
     })
 
-    it('add two nameless links to a node', (done) => {
+    it('add two nameless links to a node', async () => {
       const l1 = {
         Name: '',
         Hash: 'QmbAmuwox51c91FmC2jEX5Ng4zS4HyVgpA5GNPBF5QsWMA',
@@ -611,56 +396,41 @@ module.exports = (repo) => {
         Size: 262158
       }
 
-      const link1 = new DAGLink(l1.Name, l1.Size, Buffer.from(bs58.decode(l1.Hash)))
-      const link2 = new DAGLink(l2.Name, l2.Size, Buffer.from(bs58.decode(l2.Hash)))
+      const link1 = new DAGLink(l1.Name, l1.Tsize,
+        Buffer.from(bs58.decode(l1.Hash)))
+      const link2 = new DAGLink(l2.Name, l2.Tsize,
+        Buffer.from(bs58.decode(l2.Hash)))
 
-      DAGNode.create(Buffer.from('hiya'), [link1, link2], (err, node) => {
-        expect(err).to.not.exist()
-        done()
-      })
+      const node = await DAGNode.create(Buffer.from('hiya'), [link1, link2])
+      expect(node.Links).to.have.lengthOf(2)
     })
 
-    it('toString', (done) => {
-      DAGNode.create(Buffer.from('hello world'), (err, node) => {
-        expect(err).to.not.exist()
-        const expected = 'DAGNode <data: "aGVsbG8gd29ybGQ=", links: 0, size: 13>'
-        expect(node.toString()).to.equal(expected)
-        done()
-      })
+    it('toString', async () => {
+      const node = await DAGNode.create(Buffer.from('hello world'))
+      const expected = 'DAGNode <data: "aGVsbG8gd29ybGQ=", links: 0, size: 13>'
+      expect(node.toString()).to.equal(expected)
     })
 
-    it('deserializing a node and an object should yield the same result', (done) => {
-      expect(10).checks(done)
+    it('deserializing a node and an object should yield the same result', async () => {
       const obj = {
-        data: Buffer.from('Hello World'),
-        links: [{
-          multihash: 'QmUxD5gZfKzm8UN4WaguAMAZjw2TzZ2ZUmcqm2qXPtais7',
-          name: 'payload',
-          size: 819
+        Data: Buffer.from('Hello World'),
+        Links: [{
+          Hash: new CID('QmUxD5gZfKzm8UN4WaguAMAZjw2TzZ2ZUmcqm2qXPtais7'),
+          Name: 'payload',
+          Tsize: 819
         }]
       }
 
-      DAGNode.create(obj.data, obj.links, (err, node) => {
-        expect(err).to.not.exist.mark()
-        expect(node.data.length).to.be.above(0).mark()
-        expect(Buffer.isBuffer(node.data)).to.be.true.mark()
-        expect(node.size).to.be.above(0).mark()
+      const node = await DAGNode.create(obj.Data, obj.Links)
+      expect(node.Data.length).to.be.above(0)
+      expect(Buffer.isBuffer(node.Data)).to.be.true()
+      expect(node.size).to.be.above(0)
 
-        dagPB.util.serialize(node, (err, serialized) => {
-          expect(err).to.not.exist.mark()
-          dagPB.util.serialize(obj, (err, serializedObject) => {
-            expect(err).to.not.exist.mark()
-            dagPB.util.deserialize(serialized, (err, deserialized) => {
-              expect(err).to.not.exist.mark()
-              dagPB.util.deserialize(serializedObject, (err, deserializedObject) => {
-                expect(err).to.not.exist.mark()
-                expect(deserialized.toJSON()).to.deep.equal(deserializedObject.toJSON()).mark()
-                done()
-              })
-            })
-          })
-        })
-      })
-    }).timeout(6000)
+      const serialized = await dagPB.util.serialize(node)
+      const serializedObject = await dagPB.util.serialize(obj)
+      const deserialized = await dagPB.util.deserialize(serialized)
+      const deserializedObject = await dagPB.util.deserialize(serializedObject)
+      expect(deserialized.toJSON()).to.deep.equal(deserializedObject.toJSON())
+    })
   })
 }

--- a/test/mod.spec.js
+++ b/test/mod.spec.js
@@ -1,0 +1,20 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const multicodec = require('multicodec')
+
+const mod = require('../src')
+
+describe('IPLD Format)', () => {
+  it('multicodec is dag-pb', () => {
+    expect(mod.format).to.equal(multicodec.DAG_PB)
+  })
+
+  it('defaultHashAlg is sha2-256', () => {
+    expect(mod.defaultHashAlg).to.equal(multicodec.SHA2_256)
+  })
+})

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -1,19 +1,16 @@
 /* eslint-env mocha */
-/* eslint max-nested-callbacks: ["error", 8] */
 
 'use strict'
 
 const chai = require('chai')
+const chaiAsProised = require('chai-as-promised')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
+chai.use(chaiAsProised)
 chai.use(dirtyChai)
-const parallel = require('async/parallel')
 const CID = require('cids')
-const waterfall = require('async/waterfall')
 
-const dagPB = require('../src')
-const DAGNode = dagPB.DAGNode
-const resolver = dagPB.resolver
+const { DAGNode, resolver } = require('../src')
 const utils = require('../src/util')
 
 describe('IPLD Format resolver (local)', () => {
@@ -22,282 +19,218 @@ describe('IPLD Format resolver (local)', () => {
   let dataLinksNodeBlob
 
   const links = [{
-    name: '',
-    cid: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U',
-    size: 10
+    Name: '',
+    Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'),
+    Tsize: 10
   }, {
-    name: 'named link',
-    cid: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V',
-    size: 8
+    Name: 'named link',
+    Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V'),
+    Tsize: 8
   }]
-  const create = (data, links, callback) => waterfall([
-    (cb) => DAGNode.create(data, links, cb),
-    (n, cb) => utils.serialize(n, cb)
-  ], callback)
+  const create = async (data, links) => {
+    const node = await DAGNode.create(data, links)
+    return utils.serialize(node)
+  }
 
-  before((done) => {
-    parallel([
-      (cb) => create(Buffer.alloc(0), [], cb),
-      (cb) => create(Buffer.alloc(0), links, cb),
-      (cb) => create(Buffer.from('aaah the data'), links, cb)
-    ], (err, res) => {
-      expect(err).to.not.exist()
-      emptyNodeBlob = res[0]
-      linksNodeBlob = res[1]
-      dataLinksNodeBlob = res[2]
-      done()
-    })
-  })
-
-  it('multicodec is dag-pb', () => {
-    expect(resolver.multicodec).to.equal('dag-pb')
-  })
-
-  it('defaultHashAlg is sha2-256', () => {
-    expect(resolver.defaultHashAlg).to.equal('sha2-256')
+  before(async () => {
+    emptyNodeBlob = await create(Buffer.alloc(0), [])
+    linksNodeBlob = await create(Buffer.alloc(0), links)
+    dataLinksNodeBlob = await create(Buffer.from('aaah the data'), links)
   })
 
   describe('empty node', () => {
     describe('resolver.resolve', () => {
-      it('links path', (done) => {
-        resolver.resolve(emptyNodeBlob, 'Links', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value).to.eql([])
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('links path', async () => {
+        const result = await resolver.resolve(emptyNodeBlob, 'Links')
+        expect(result.value).to.eql([])
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('data path', (done) => {
-        resolver.resolve(emptyNodeBlob, 'Data', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value).to.eql(Buffer.alloc(0))
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('data path', async () => {
+        const result = await resolver.resolve(emptyNodeBlob, 'Data')
+        expect(result.value).to.eql(Buffer.alloc(0))
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('non existent path', (done) => {
-        resolver.resolve(emptyNodeBlob, 'pathThatDoesNotExist', (err, result) => {
-          expect(err).to.exist()
-          done()
-        })
+      it('non existent path', async () => {
+        await expect(
+          resolver.resolve(emptyNodeBlob, 'pathThatDoesNotExist')
+        ).to.be.rejectedWith(
+          "Object has no property 'pathThatDoesNotExist'"
+        )
       })
 
-      it('empty path', (done) => {
-        resolver.resolve(emptyNodeBlob, '', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value.data).to.eql(Buffer.alloc(0))
-          expect(result.value.links).to.eql([])
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('empty path', async () => {
+        const result = await resolver.resolve(emptyNodeBlob, '')
+        expect(result.value.Data).to.eql(Buffer.alloc(0))
+        expect(result.value.Links).to.eql([])
+        expect(result.remainderPath).to.eql('')
       })
     })
 
-    it('resolver.tree', (done) => {
-      resolver.tree(emptyNodeBlob, (err, paths) => {
-        expect(err).to.not.exist()
-        expect(paths).to.eql([
-          'Links',
-          'Data'
-        ])
-        done()
-      })
+    it('resolver.tree', async () => {
+      const tree = resolver.tree(emptyNodeBlob)
+      const paths = []
+      for await (const path of tree) {
+        paths.push(path)
+      }
+      expect(paths).to.have.members([
+        'Links',
+        'Data'
+      ])
     })
   })
 
   describe('links node', () => {
     describe('resolver.resolve', () => {
-      it('links path', (done) => {
-        resolver.resolve(linksNodeBlob, 'Links', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value).to.eql(links)
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('links path', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'Links')
+        expect(result.value).to.eql(links)
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('links position path Hash', (done) => {
-        resolver.resolve(linksNodeBlob, 'Links/1/Hash', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value['/']).to.eql(links[1].cid)
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('links position path Hash', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'Links/1/Hash')
+        expect(result.value).to.eql(links[1].Hash)
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('links position path Name', (done) => {
-        resolver.resolve(linksNodeBlob, 'Links/1/Name', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value).to.eql(links[1].name)
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('links position path Name', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'Links/1/Name')
+        expect(result.value).to.eql(links[1].Name)
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('links position path Tsize', (done) => {
-        resolver.resolve(linksNodeBlob, 'Links/1/Tsize', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value).to.eql(links[1].size)
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('links position path Tsize', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'Links/1/Tsize')
+        expect(result.value).to.eql(links[1].Tsize)
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('links by name', (done) => {
-        resolver.resolve(linksNodeBlob, 'named link', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value['/']).to.eql(links[1].cid)
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('links by name', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'named link')
+        expect(result.value.Hash.equals(links[1].Hash)).to.be.true()
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('missing link by name', (done) => {
-        resolver.resolve(linksNodeBlob, 'missing link', (err, result) => {
-          expect(err).to.exist()
-          expect(err.message).to.equal('path not available')
-          done()
-        })
+      it('missing link by name', async () => {
+        await expect(
+          resolver.resolve(linksNodeBlob, 'missing link')
+        ).to.be.rejectedWith(
+          "Object has no property 'missing link'"
+        )
       })
 
-      it('yield remainderPath if impossible to resolve through (a)', (done) => {
-        resolver.resolve(linksNodeBlob, 'Links/1/Hash/Data', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value['/']).to.exist()
-          expect(result.value['/']).to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
-          expect(result.remainderPath).to.equal('Data')
-          done()
-        })
+      it('yield remainderPath if impossible to resolve through (a)', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'Links/1/Hash/Data')
+        expect(result.value.equals(
+          new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
+        )).to.be.true()
+        expect(result.remainderPath).to.equal('Data')
       })
 
-      it('yield remainderPath if impossible to resolve through (b)', (done) => {
-        resolver.resolve(linksNodeBlob, 'Links/1/Hash/Links/0/Hash/Data', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value['/'])
-            .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
-
-          expect(result.remainderPath).to.equal('Links/0/Hash/Data')
-          done()
-        })
+      it('yield remainderPath if impossible to resolve through (b)', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'Links/1/Hash/Links/0/Hash/Data')
+        expect(result.value.equals(
+          new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
+        )).to.be.true()
+        expect(result.remainderPath).to.equal('Links/0/Hash/Data')
       })
 
-      it('yield remainderPath if impossible to resolve through named link (a)', (done) => {
-        resolver.resolve(linksNodeBlob, 'named link/Data', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value['/']).to.exist()
-          expect(result.value['/']).to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
-          expect(result.remainderPath).to.equal('Data')
-          done()
-        })
+      it('yield remainderPath if impossible to resolve through named link (a)', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'named link/Hash/Data')
+        expect(result.value.equals(
+          new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
+        )).to.be.true()
+        expect(result.remainderPath).to.equal('Data')
       })
 
-      it('yield remainderPath if impossible to resolve through named link (b)', (done) => {
-        resolver.resolve(linksNodeBlob, 'named link/Links/0/Hash/Data', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value['/'])
-            .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
-
-          expect(result.remainderPath).to.equal('Links/0/Hash/Data')
-          done()
-        })
+      it('yield remainderPath if impossible to resolve through named link (b)', async () => {
+        const result = await resolver.resolve(linksNodeBlob, 'named link/Hash/Links/0/Hash/Data')
+        expect(result.value.equals(
+          new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
+        )).to.be.true()
+        expect(result.remainderPath).to.equal('Links/0/Hash/Data')
       })
     })
 
-    it('resolver.tree', (done) => {
-      resolver.tree(linksNodeBlob, (err, paths) => {
-        expect(err).to.not.exist()
-        expect(paths).to.eql([
-          'Links',
-          'Links/0/Name',
-          'Links/0/Tsize',
-          'Links/0/Hash',
-          'Links/1/Name',
-          'Links/1/Tsize',
-          'Links/1/Hash',
-          'Data'
-        ])
-        done()
-      })
+    it('resolver.tree', async () => {
+      const tree = resolver.tree(linksNodeBlob)
+      const paths = []
+      for await (const path of tree) {
+        paths.push(path)
+      }
+      expect(paths).to.have.members([
+        'Links',
+        'Links/0',
+        'Links/0/Name',
+        'Links/0/Tsize',
+        'Links/0/Hash',
+        'Links/1',
+        'Links/1/Name',
+        'Links/1/Tsize',
+        'Links/1/Hash',
+        'Data',
+        'named link',
+        'named link/Name',
+        'named link/Tsize',
+        'named link/Hash'
+      ])
     })
   })
 
   describe('links and data node', () => {
-    describe('resolver.resolve', (done) => {
-      it('links path', (done) => {
-        resolver.resolve(dataLinksNodeBlob, 'Links', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value).to.eql(links)
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+    describe('resolver.resolve', async () => {
+      it('links path', async () => {
+        const result = await resolver.resolve(dataLinksNodeBlob, 'Links')
+        expect(result.value).to.eql(links)
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('data path', (done) => {
-        resolver.resolve(dataLinksNodeBlob, 'Data', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value).to.eql(Buffer.from('aaah the data'))
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('data path', async () => {
+        const result = await resolver.resolve(dataLinksNodeBlob, 'Data')
+        expect(result.value).to.eql(Buffer.from('aaah the data'))
+        expect(result.remainderPath).to.eql('')
       })
 
-      it('non existent path', (done) => {
-        resolver.resolve(dataLinksNodeBlob, 'pathThatDoesNotExist', (err, result) => {
-          expect(err).to.exist()
-          done()
-        })
+      it('non existent path', async () => {
+        await expect(
+          resolver.resolve(dataLinksNodeBlob, 'pathThatDoesNotExist')
+        ).to.be.rejectedWith(
+          "Object has no property 'pathThatDoesNotExist'"
+        )
       })
 
-      it('empty path', (done) => {
-        resolver.resolve(dataLinksNodeBlob, '', (err, result) => {
-          expect(err).to.not.exist()
-          expect(result.value.data).to.eql(Buffer.from('aaah the data'))
-          expect(result.value.links.map((link) => link.toJSON())).to.eql(links)
-          expect(result.remainderPath).to.eql('')
-          done()
-        })
+      it('empty path', async () => {
+        const result = await resolver.resolve(dataLinksNodeBlob, '')
+        expect(result.value.Data).to.eql(Buffer.from('aaah the data'))
+        expect(result.value.Links).to.eql(links)
+        expect(result.remainderPath).to.eql('')
       })
     })
 
-    it('resolver.tree', (done) => {
-      resolver.tree(dataLinksNodeBlob, (err, paths) => {
-        expect(err).to.not.exist()
-        expect(paths).to.eql([
-          'Links',
-          'Links/0/Name',
-          'Links/0/Tsize',
-          'Links/0/Hash',
-          'Links/1/Name',
-          'Links/1/Tsize',
-          'Links/1/Hash',
-          'Data'
-        ])
-        done()
-      })
-    })
-  })
-
-  it('resolver.isLink for valid CID', (done) => {
-    resolver.isLink(dataLinksNodeBlob, 'Links/0/Hash', (err, link) => {
-      expect(err).to.not.exist()
-      expect(CID.isCID(new CID(link['/']))).to.equal(true)
-      done()
-    })
-  })
-
-  it('resolver.isLink for non valid CID', (done) => {
-    // blank value case
-    resolver.isLink(dataLinksNodeBlob, 'Links/0/Name', (err, link) => {
-      expect(err).to.not.exist()
-      expect(link).to.equal(false)
-      // non-blank value case
-      resolver.isLink(dataLinksNodeBlob, 'Links/0/Tsize', (err, link) => {
-        expect(err).to.not.exist()
-        expect(link).to.equal(false)
-        done()
-      })
+    it('resolver.tree', async () => {
+      const tree = resolver.tree(dataLinksNodeBlob)
+      const paths = []
+      for await (const path of tree) {
+        paths.push(path)
+      }
+      expect(paths).to.have.members([
+        'Links',
+        'Links/0',
+        'Links/0/Name',
+        'Links/0/Tsize',
+        'Links/0/Hash',
+        'Links/1',
+        'Links/1/Name',
+        'Links/1/Tsize',
+        'Links/1/Hash',
+        'Data',
+        'named link',
+        'named link/Name',
+        'named link/Tsize',
+        'named link/Hash'
+      ])
     })
   })
 })

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const CID = require('cids')
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
@@ -16,82 +17,51 @@ const {
 } = require('../src/util')
 
 describe('util', () => {
-  it('should serialize an empty node', (done) => {
-    serialize({}, (error, result) => {
-      expect(error).to.not.exist()
-      expect(result).to.be.an.instanceof(Buffer)
-      expect(result).to.be.empty()
-      done()
-    })
+  it('should serialize an empty node', async () => {
+    const result = await serialize({})
+    expect(result).to.be.an.instanceof(Uint8Array)
+    expect(result).to.be.empty()
   })
 
-  it('should serialize a node with data', (done) => {
+  it('should serialize a node with data', async () => {
     const data = Buffer.from([0, 1, 2, 3])
-    serialize({
-      data
-    }, (error, result) => {
-      expect(error).to.not.exist()
-      expect(result).to.be.an.instanceof(Buffer)
+    const result = await serialize({ Data: data })
+    expect(result).to.be.an.instanceof(Uint8Array)
 
-      deserialize(result, (error, node) => {
-        expect(error).to.not.exist()
-        expect(node.data).to.deep.equal(data)
-
-        done()
-      })
-    })
+    const node = await deserialize(result)
+    expect(node.Data).to.deep.equal(data)
   })
 
-  it('should serialize a node with links', (done) => {
+  it('should serialize a node with links', async () => {
     const links = [
       new DAGLink('', 0, 'QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
     ]
-    serialize({
-      links
-    }, (error, result) => {
-      expect(error).to.not.exist()
-      expect(result).to.be.an.instanceof(Buffer)
+    const result = await serialize({ Links: links })
+    expect(result).to.be.an.instanceof(Uint8Array)
 
-      deserialize(result, (error, node) => {
-        expect(error).to.not.exist()
-        expect(node.links).to.deep.equal(links)
-
-        done()
-      })
-    })
+    const node = await deserialize(result)
+    expect(node.Links).to.deep.equal([{
+      Name: '',
+      Tsize: 0,
+      Hash: new CID('QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
+    }])
   })
 
-  it('should serialize a node with links as plain objects', (done) => {
+  it('should serialize a node with links as plain objects', async () => {
     const links = [{
-      name: '',
-      size: 0,
-      hash: 'QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe'
+      Name: '',
+      Tsize: 0,
+      Hash: new CID('QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
     }]
-    serialize({
-      links
-    }, (error, result) => {
-      expect(error).to.not.exist()
-      expect(result).to.be.an.instanceof(Buffer)
+    const result = await serialize({ Links: links })
+    expect(result).to.be.an.instanceof(Uint8Array)
 
-      deserialize(result, (error, node) => {
-        expect(error).to.not.exist()
-        expect(node.links).to.deep.equal([
-          new DAGLink('', 0, 'QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
-        ])
-
-        done()
-      })
-    })
+    const node = await deserialize(result)
+    expect(node.Links).to.deep.equal(links)
   })
 
-  it('should ignore invalid properties when serializing', (done) => {
-    serialize({
-      foo: 'bar'
-    }, (error, result) => {
-      expect(error).to.not.exist()
-      expect(result).to.be.an.instanceof(Buffer)
-      expect(result).to.be.empty()
-      done()
-    })
+  it('should ignore invalid properties when serializing', async () => {
+    const result = await serialize({ foo: 'bar' })
+    expect(result).to.be.empty()
   })
 })


### PR DESCRIPTION
BREAKING CHANGE: The API is now async/await based

There are numerous changes, the most significant one is that the API
is no longer callback based, but it using async/await.

The properties of DAGNode and DAGLink are now in sync with the paths
that are used for resolving. This means that e.g. `name` is now called
`Name` and `size` is `Tsize`.

All return values from `resolve()` now conform to the [IPLD Data Model],
this means that e.g. links are no longer represented as
`{'/': "baseecodedcid"}`, but as [CID] instances instead.

For the full new API please see the [IPLD Formats spec].

[IPLD Data Model]: https://github.com/ipld/specs/blob/master/IPLD-Data-Model-v1.md
[CID]: https://github.com/multiformats/js-cid/
[IPLD Formats spec]: https://github.com/ipld/interface-ipld-format