### PR TITLE
fix: allow adding links from DAGNode.Links

### DIFF
--- a/src/dag-node/addLink.js
+++ b/src/dag-node/addLink.js
@@ -22,7 +22,7 @@ const asDAGLink = async (link) => {
   }
 
   // It's a Object with name, multihash/hash/cid and size
-  return new DAGLink(link.name, link.size, link.multihash || link.hash || link.cid)
+  return new DAGLink(link.Name || link.name, link.Tsize || link.size, link.Hash || link.multihash || link.hash || link.cid)
 }
 
 const addLink = async (node, link) => {

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -183,6 +183,25 @@ module.exports = (repo) => {
       expect(node1c.Links.length).to.equal(2)
     })
 
+    it('addLink by DAGNode.Links', async () => {
+      const linkName = 'link-name'
+      const remote = DAGNode.create(Buffer.from('2'))
+      const source = await DAGNode.addLink(
+        DAGNode.create(Buffer.from('1')), await toDAGLink(remote, {
+          name: linkName
+        })
+      )
+
+      expect(source.Links.length).to.equal(1)
+
+      let target = new DAGNode(null, [], 0)
+      target = await DAGNode.addLink(target, source.Links[0])
+
+      expect(target.Links.length).to.equal(1)
+      expect(target.Links[0].Tsize).to.eql(remote.size)
+      expect(target.Links[0].Name).to.be.eql(linkName)
+    })
+
     it('rmLink by name', async () => {
       const node1a = DAGNode.create(Buffer.from('1'))
       expect(node1a.Links.length).to.eql(0)


### PR DESCRIPTION
`DAGNode.Links` converts `DAGLink` objects into vanilla JS objects. `DAGNode.addLink` accepts vanilla JS objects as links but looks for different properties from the ones the return value of `DAGNode.Links` have (e.g. `.Hash` vs `.cid`, etc)..

This PR corrects the behaviour to look for those properties names and adds a test for the same.