### PR TITLE
fix: support .Size property

### DIFF
--- a/src/dag-link/util.js
+++ b/src/dag-link/util.js
@@ -4,9 +4,9 @@ const DAGLink = require('./index')
 
 function createDagLinkFromB58EncodedHash (link) {
   return new DAGLink(
-    link.name ? link.name : link.Name,
-    link.size ? link.size : link.Tsize,
-    link.hash || link.Hash || link.multihash || link.cid
+    link.Name || link.name || '',
+    link.Tsize || link.Size || link.size || 0,
+    link.Hash || link.hash || link.multihash || link.cid
   )
 }
 

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -424,5 +424,14 @@ module.exports = (repo) => {
       const deserializedObject = dagPB.util.deserialize(serializedObject)
       expect(deserialized.toJSON()).to.deep.equal(deserializedObject.toJSON())
     })
+
+    it('creates links from objects with .Size properties', () => {
+      const node = DAGNode.create(Buffer.from('some data'), [{
+        Hash: 'QmUxD5gZfKzm8UN4WaguAMAZjw2TzZ2ZUmcqm2qXPtais7',
+        Size: 9001
+      }])
+
+      expect(node.Links[0].Tsize).to.eql(9001)
+    })
   })
 }


### PR DESCRIPTION
At some point in the distant past we supported a `.Size` property for `DAGLink`s so this PR adds that back in.

Also reorders the properties so the most recent (hopefully the most common) are first.