### PR TITLE
fix: named links should return the CID

### DIFF
--- a/src/dag-node/addNamedLink.js
+++ b/src/dag-node/addNamedLink.js
@@ -18,7 +18,7 @@ const addNamedLink = (object, name, position) => {
   Object.defineProperty(object, name, {
     enumerable: true,
     configurable: true,
-    get: () => object._links[position]
+    get: () => object._links[position].Hash
   })
 }
 

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -99,7 +99,7 @@ describe('IPLD Format resolver (local)', () => {
 
       it('links by name', () => {
         const result = resolver.resolve(linksNodeBlob, 'named link')
-        expect(result.value.Hash.equals(links[1].Hash)).to.be.true()
+        expect(result.value.equals(links[1].Hash)).to.be.true()
         expect(result.remainderPath).to.eql('')
       })
 
@@ -128,7 +128,7 @@ describe('IPLD Format resolver (local)', () => {
       })
 
       it('yield remainderPath if impossible to resolve through named link (a)', () => {
-        const result = resolver.resolve(linksNodeBlob, 'named link/Hash/Data')
+        const result = resolver.resolve(linksNodeBlob, 'named link/Data')
         expect(result.value.equals(
           new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
         )).to.be.true()
@@ -136,7 +136,7 @@ describe('IPLD Format resolver (local)', () => {
       })
 
       it('yield remainderPath if impossible to resolve through named link (b)', () => {
-        const result = resolver.resolve(linksNodeBlob, 'named link/Hash/Links/0/Hash/Data')
+        const result = resolver.resolve(linksNodeBlob, 'named link/Links/0/Hash/Data')
         expect(result.value.equals(
           new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
         )).to.be.true()
@@ -158,10 +158,7 @@ describe('IPLD Format resolver (local)', () => {
         'Links/1/Tsize',
         'Links/1/Hash',
         'Data',
-        'named link',
-        'named link/Name',
-        'named link/Tsize',
-        'named link/Hash'
+        'named link'
       ])
     })
   })
@@ -210,10 +207,7 @@ describe('IPLD Format resolver (local)', () => {
         'Links/1/Tsize',
         'Links/1/Hash',
         'Data',
-        'named link',
-        'named link/Name',
-        'named link/Tsize',
-        'named link/Hash'
+        'named link'
       ])
     })
   })


### PR DESCRIPTION
Prior to this change, named links didn't return the CID they are
pointing to, but the DAGLink. This made proper named links traversal
as it is done by UnixFSv1 impossible.

Thanks @alanshaw for finding and providing a solution to this bug.