### PR TITLE
fix: put named links into its own property

### DIFF
--- a/src/dag-node/addNamedLink.js
+++ b/src/dag-node/addNamedLink.js
@@ -15,11 +15,7 @@ const addNamedLink = (object, name, position) => {
   if (skipNames.includes(name)) {
     return
   }
-  Object.defineProperty(object, name, {
-    enumerable: true,
-    configurable: true,
-    get: () => object._links[position].Hash
-  })
+  object._namedLinks[name] = object._links[position].Hash
 }
 
 module.exports = addNamedLink

--- a/src/dag-node/index.js
+++ b/src/dag-node/index.js
@@ -14,6 +14,7 @@ class DAGNode {
     this._data = data || Buffer.alloc(0)
     this._links = links
     this._serializedSize = serializedSize
+    this._namedLinks = {}
 
     // Make sure we have a nice public API that can be used by an IPLD resolver
     visibility.hidePrivateFields(this)

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -25,10 +25,16 @@ exports.resolve = (binaryBlob, path) => {
   while (parts.length) {
     const key = parts.shift()
     if (node[key] === undefined) {
-      throw new Error(`Object has no property '${key}'`)
+      // Check the named links
+      if (node._namedLinks[key] === undefined) {
+        throw new Error(`Object has no property '${key}'`)
+      } else {
+        node = node._namedLinks[key]
+      }
+    } else {
+      node = node[key]
     }
 
-    node = node[key]
     if (CID.isCID(node)) {
       return {
         value: node,
@@ -67,4 +73,9 @@ exports.tree = function * (binaryBlob) {
   const node = util.deserialize(binaryBlob)
 
   yield * traverse(node)
+
+  // The named links are in a separate property
+  for (const namedLink of Object.keys(node._namedLinks)) {
+    yield namedLink
+  }
 }

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -107,6 +107,15 @@ module.exports = (repo) => {
       }
     })
 
+    it('create with link named like a private property', () => {
+      const node = DAGNode.create(Buffer.from('hello'), [
+        new DAGLink(
+          '_links', 10, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'
+        )
+      ])
+      expect(node.Links[0].Name).to.be.eql('_links')
+    })
+
     it('create an empty node', () => {
       // this node is not in the repo as we don't copy node data to the browser
       const node = DAGNode.create(Buffer.alloc(0))
@@ -162,12 +171,12 @@ module.exports = (repo) => {
       const node1a = DAGNode.create(Buffer.from('1'))
       const node2 = DAGNode.create(Buffer.from('2'))
       const link = await toDAGLink(node2, { name: 'banana' })
-      expect(Object.keys(node1a)).to.not.include('banana')
+      expect(Object.keys(node1a._namedLinks)).to.not.include('banana')
       const node1b = await DAGNode.addLink(node1a, link)
       expect(node1b.Links.length).to.equal(1)
       expect(node1b.Links[0].Tsize).to.eql(node2.size)
       expect(node1b.Links[0].Name).to.eql('banana')
-      expect(Object.keys(node1b)).to.include('banana')
+      expect(Object.keys(node1b._namedLinks)).to.include('banana')
     })
 
     it('addLink - add several links', async () => {
@@ -212,9 +221,9 @@ module.exports = (repo) => {
 
       const node1b = await DAGNode.addLink(node1a, link)
       expect(node1b.Links.length).to.eql(1)
-      expect(Object.keys(node1b)).to.include('banana')
+      expect(Object.keys(node1b._namedLinks)).to.include('banana')
       const node1c = DAGNode.rmLink(node1b, 'banana')
-      expect(Object.keys(node1c)).to.not.include('banana')
+      expect(Object.keys(node1c._namedLinks)).to.not.include('banana')
       expect(node1c.Links.length).to.eql(0)
       expect(node1c.toJSON()).to.eql(withoutLink)
     })
@@ -229,9 +238,9 @@ module.exports = (repo) => {
 
       const node1b = await DAGNode.addLink(node1a, link)
       expect(node1b.Links.length).to.eql(1)
-      expect(Object.keys(node1b)).to.include('banana')
+      expect(Object.keys(node1b._namedLinks)).to.include('banana')
       const node1c = DAGNode.rmLink(node1b, node1b.Links[0].Hash)
-      expect(Object.keys(node1c)).to.not.include('banana')
+      expect(Object.keys(node1c._namedLinks)).to.not.include('banana')
       expect(node1c.Links.length).to.eql(0)
       expect(node1c.toJSON()).to.eql(withoutLink)
     })


### PR DESCRIPTION
BREAKING CHANGE: Named links are no longer accessible directly on the object

Named links can still be used for resolving, but those links are no
longer accessible directly on the object.