### PR TITLE
fix: actually use object keys

### DIFF
--- a/src/dag-node/addNamedLink.js
+++ b/src/dag-node/addNamedLink.js
@@ -11,7 +11,7 @@
  * @param {numner} position - The position within the array of links
  */
 const addNamedLink = (object, name, position) => {
-  const skipNames = ['', ...Object.keys(this)]
+  const skipNames = ['', ...Object.keys(object)]
   if (skipNames.includes(name)) {
     return
   }


### PR DESCRIPTION
The code was wrong, it didn't actually use the keys of the object.
This also broke things in Browser environments.

Fixes https://github.com/ipfs/js-ipfs/issues/2090.