### PR TITLE
chore: remove dependency on async

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,17 +71,14 @@
   },
   "devDependencies": {
     "aegir": "^18.2.2",
-    "async": "^2.6.2",
     "bs58": "^4.0.1",
     "chai": "^4.2.0",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
+    "fs-extra": "^8.0.1",
     "ipfs-block": "~0.8.0",
-    "ipfs-block-service": "~0.15.2",
-    "ipfs-repo": "~0.26.4",
-    "multihashes": "~0.4.14",
-    "ncp": "^2.0.0",
-    "promisify-es6": "^1.0.3",
-    "rimraf": "^2.6.3"
+    "ipfs-block-service": "~0.16.0",
+    "ipfs-repo": "~0.27.0",
+    "multihashes": "~0.4.14"
   }
 }

--- a/test/browser.js
+++ b/test/browser.js
@@ -3,7 +3,6 @@
 
 'use strict'
 
-const series = require('async/series')
 const IPFSRepo = require('ipfs-repo')
 
 const basePath = 'ipfs' + Math.random()
@@ -19,22 +18,15 @@ idb.deleteDatabase(basePath + '/blocks')
 describe('Browser', () => {
   const repo = new IPFSRepo(basePath)
 
-  before((done) => {
-    series([
-      (cb) => repo.init({}, cb),
-      (cb) => repo.open(cb)
-    ], done)
+  before(async () => {
+    await repo.init({})
+    await repo.open()
   })
 
-  after((done) => {
-    series([
-      (cb) => repo.close(cb),
-      (cb) => {
-        idb.deleteDatabase(basePath)
-        idb.deleteDatabase(basePath + '/blocks')
-        cb()
-      }
-    ], done)
+  after(async () => {
+    await repo.close()
+    idb.deleteDatabase(basePath)
+    idb.deleteDatabase(basePath + '/blocks')
   })
 
   require('./dag-node-test')(repo)

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -13,7 +13,6 @@ const toDAGLink = require('../src/dag-node/util').toDAGLink
 const isNode = require('detect-node')
 const multihash = require('multihashes')
 const multicodec = require('multicodec')
-const promisify = require('promisify-es6')
 
 const BlockService = require('ipfs-block-service')
 const Block = require('ipfs-block')
@@ -25,11 +24,7 @@ const testBlockNamedLinks = loadFixture('test/fixtures/test-block-named-links')
 const testBlockUnnamedLinks = loadFixture('test/fixtures/test-block-unnamed-links')
 
 module.exports = (repo) => {
-  const _bs = new BlockService(repo)
-  const bs = {
-    get: promisify(_bs.get.bind(_bs)),
-    put: promisify(_bs.put.bind(_bs))
-  }
+  const bs = new BlockService(repo)
 
   describe('DAGNode', () => {
     it('create a node', () => {

--- a/test/node.js
+++ b/test/node.js
@@ -1,10 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
-const ncp = require('ncp').ncp
-const rimraf = require('rimraf')
+const fs = require('fs-extra')
 const IPFSRepo = require('ipfs-repo')
-const series = require('async/series')
 const os = require('os')
 
 describe('Node.js', () => {
@@ -12,18 +10,14 @@ describe('Node.js', () => {
   const repoTests = os.tmpdir() + '/t-r-' + Date.now()
   const repo = new IPFSRepo(repoTests)
 
-  before((done) => {
-    series([
-      (cb) => ncp(repoExample, repoTests, cb),
-      (cb) => repo.open(cb)
-    ], done)
+  before(async () => {
+    await fs.copy(repoExample, repoTests)
+    await repo.open()
   })
 
-  after((done) => {
-    series([
-      (cb) => repo.close(cb),
-      (cb) => rimraf(repoTests, cb)
-    ], done)
+  after(async () => {
+    await repo.close()
+    await fs.remove(repoTests)
   })
 
   require('./dag-link-test')(repo)


### PR DESCRIPTION
As we are moving from callbacks to async/await, it makes sense to
remove all occurrences of the async module.