### PR TITLE
fix: serialization portability problems and size calculation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ links can be a single or an array of DAGLinks instances or objects with the foll
 }
 ```
 
-
-
 ### DAGNode instance methods and properties
 
 You have the following methods and properties available in every DAGNode instance.
@@ -166,7 +164,7 @@ const link = node.toDAGLink()
 const link = node.toDAGLink({ name: 'name-of-the-link' })
 ```
 
-#### addLink(link)
+#### `node.addLink(link)`
 
 - `link` - type: DAGLink or DAGLink in its json format
 
@@ -187,7 +185,7 @@ const link = {
 node.addLink(link)
 ```
 
-#### rmLink(nameOrCid)
+#### `node.rmLink(nameOrCid)`
 
 - `nameOrCid` - type: String, CID object or CID buffer
 
@@ -197,6 +195,9 @@ Removes a link from the node by name. Modifies the node.
 node.rmLink('Link1')
 ```
 
+#### `node.serialize()`
+
+Serialize the DAGNode instance to its portable binary format. Yields the same result as `dagPB.util.serialize(node)`. Returns a `Buffer`.
 
 ### DAGLink functions
 
@@ -249,7 +250,11 @@ const link = new DAGLink(
 
 ### `dagPB.util.serialize`
 
+Serialize the DAGNode instance to its portable binary format. Yields the same result as `node.serialize()`. Returns a `Buffer`.
+
 ### `dagPB.util.deserialize`
+
+Deserialize a DAGNode instance from its portable binary format. Returns a DAGNode.
 
 ## Contribute
 

--- a/src/dag-node/toDagLink.js
+++ b/src/dag-node/toDagLink.js
@@ -1,16 +1,14 @@
 'use strict'
 
 const DAGLink = require('../dag-link/dagLink')
-const { serializeDAGNode } = require('../serialize')
 const genCid = require('../genCid')
 
 /*
  * toDAGLink converts a DAGNode to a DAGLink
  */
 const toDAGLink = async (node, options = {}) => {
-  const serialized = serializeDAGNode(node)
-  const nodeCid = await genCid.cid(serialized)
-  return new DAGLink(options.name || '', serialized.length, nodeCid)
+  const nodeCid = await genCid.cid(node.serialize(), options)
+  return new DAGLink(options.name || '', node.size, nodeCid)
 }
 
 module.exports = toDAGLink

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -34,7 +34,7 @@ const toProtoBuf = (node) => {
 /**
  * Serialize internal representation into a binary PB block.
  *
- * @param {Object} node - Internal representation of a CBOR block
+ * @param {Object} node - Internal representation of a PB block
  * @returns {Buffer} - The encoded binary representation
  */
 const serializeDAGNode = (node) => {

--- a/src/util.js
+++ b/src/util.js
@@ -4,7 +4,7 @@ const protons = require('protons')
 const proto = protons(require('./dag.proto'))
 const DAGLink = require('./dag-link/dagLink')
 const DAGNode = require('./dag-node/dagNode')
-const { serializeDAGNode, serializeDAGNodeLike } = require('./serialize')
+const { serializeDAGNodeLike } = require('./serialize')
 const genCid = require('./genCid')
 
 exports = module.exports
@@ -33,7 +33,7 @@ const cid = (binaryBlob, userOptions) => {
  */
 const serialize = (node) => {
   if (DAGNode.isDAGNode(node)) {
-    return serializeDAGNode(node)
+    return node.serialize()
   } else {
     return serializeDAGNodeLike(node.Data, node.Links)
   }

--- a/tools/pb-cross-language.go
+++ b/tools/pb-cross-language.go
@@ -1,0 +1,47 @@
+// For testing cross-language PB data to make sure we're producing the same thing
+// `go get github.com/ipfs/go-merkledag`
+// `go run pb-cross-language.go`
+/*
+pnd1 cid: QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n, size: 0
+pnd2 cid: QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n, size: 0
+pnd3 cid: QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n, size: 0
+pnd1 cid: QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT, size: 51
+pnd2 cid: QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys, size: 149
+pnd3 cid: QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d, size: 250
+*/
+
+// based on test data from https://github.com/ipfs/go-car
+
+package main
+
+import (
+	"fmt"
+
+	dag "github.com/ipfs/go-merkledag"
+)
+
+func main() {
+	var rnd1 = dag.NewRawNode([]byte("aaaa"))
+	var rnd2 = dag.NewRawNode([]byte("bbbb"))
+	var rnd3 = dag.NewRawNode([]byte("cccc"))
+
+	var pnd1 = &dag.ProtoNode{}
+	var pnd2 = &dag.ProtoNode{}
+	var pnd3 = &dag.ProtoNode{}
+
+	sizer := func(pnd *dag.ProtoNode) (size uint64) { size, _ = pnd.Size(); return size }
+
+	fmt.Printf("pnd1 cid: %s, size: %d\n", pnd1.Cid(), sizer(pnd1))
+	fmt.Printf("pnd2 cid: %s, size: %d\n", pnd2.Cid(), sizer(pnd2))
+	fmt.Printf("pnd3 cid: %s, size: %d\n", pnd3.Cid(), sizer(pnd3))
+
+	pnd1.AddNodeLink("cat", rnd1)
+	pnd2.AddNodeLink("first", pnd1)
+	pnd2.AddNodeLink("dog", rnd2)
+	pnd3.AddNodeLink("second", pnd2)
+	pnd3.AddNodeLink("bear", rnd3)
+
+	fmt.Printf("pnd1 cid: %s, size: %d\n", pnd1.Cid(), sizer(pnd1))
+	fmt.Printf("pnd2 cid: %s, size: %d\n", pnd2.Cid(), sizer(pnd2))
+	fmt.Printf("pnd3 cid: %s, size: %d\n", pnd3.Cid(), sizer(pnd3))
+}


### PR DESCRIPTION
2 bugs I discovered while trying to write my zip archive format for non-trivial portable test fixture data (i.e. my JS version of https://github.com/rvagg/go-ds-zipcar wasn't giving me the same CIDs).

1. `DAGNode` used to be immutable, `addLink()` and `rmLink()` would return new nodes on their callbacks. The current incarnation, since #141, mutates the current node, this means that `node._serializedSize` is incorrect upon either mutation operation. To fix this I've reset the cached sizing data and it's lazily re-calculated when you call `node.size` (as it is if you call the constructor without `serializedSize`).
2. `DAGNode#toDAGLink()` uses _serialized node size_ rather than _node size_ to create the new link, this is not how the Go implementation does it. That happened in #127 and I think it was simply a mistake.

Since `node._serializedSize` needs to be calculated lazily now (sometimes it's never set, sometimes the node mutates), I added a `node.serialize()` to do the work which makes for a really nice API instead of having to go through `dagPB.util.serialize(node)` (I wouldn't mind a `DAGNode.deserialize(buf)` too to get rid of the need to use `dagPB.util` entirely tbh but maybe that can come later).

Also added some Go code to the test/ dir that generates the fixture data I used in the tests I added.

I'd normally just call the above two items critical bug fixes but I've labelled them "BREAKING CHANGE" because I'm not sure what the criteria for "breaking" is in this repo.

-------

    feat: DAGNode#serialize() is now a synonym for
    dagPB.util.serialize(node).

    BREAKING CHANGE: `node.addLink()` and `node.rmLink()` (node mutation
    operations) will now reset any cached size data causing sizing and
    serialization to be performed from the new state when required.

    BREAKING CHANGE: (fix) `node.toDAGLink()` (and therefore
    `node.addLink(DAGNode)` indirectly) now use the `node.size()` value for
    link size rather than the node's serialized byte size, yielding different
    serialized nodes and CIDs. This matches the Go implementation, see
    github.com/ipfs/go-ipld-format's `node.MakeLink()`.