### PR TITLE
feat: ignore tsize property on pblinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# js-ipld-dag-pb
+# js-ipld-dag-pb <!-- omit in toc -->
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPLD-blue.svg?style=flat-square)](http://github.com/ipld/ipld)
@@ -14,11 +14,11 @@
 
 > JavaScript Implementation of the IPLD Format MerkleDAG Node in Protobuf. In addition to the IPLD Format methods, this module also provides an API for creating the nodes and manipulating them (adding and removing links, etc).
 
-## Lead Maintainer
+## Lead Maintainer <!-- omit in toc -->
 
 [Volker Mische](https://github.com/vmx)
 
-## Table of Contents
+## Table of Contents <!-- omit in toc -->
 
 - [Install](#install)
 - [Usage](#usage)
@@ -31,24 +31,23 @@
   - [DAGNode instance methods and properties](#dagnode-instance-methods-and-properties)
     - [`node.Data`](#nodedata)
     - [`node.Links`](#nodelinks)
-    - [`node.size`](#nodesize)
     - [`node.toJSON()`](#nodetojson)
     - [`node.toString()`](#nodetostring)
-    - [`node.toDAGLink(options)`](#nodetodaglinkoptions)
+    - [`node.toDAGLink()`](#nodetodaglink)
     - [`node.addLink(link)`](#nodeaddlinklink)
     - [`node.rmLink(nameOrCid)`](#nodermlinknameorcid)
+    - [`node.serialize()`](#nodeserialize)
   - [DAGLink functions](#daglink-functions)
     - [DAGLink constructor](#daglink-constructor)
   - [DAGLink instance methods and properties](#daglink-instance-methods-and-properties)
     - [`link.Name`](#linkname)
-    - [`link.Tsize`](#linktsize)
     - [`link.Hash`](#linkhash)
     - [`link.toJSON()`](#linktojson)
     - [`link.toString()`](#linktostring)
-  - [[IPLD Format Specifics](https://github.com/ipld/interface-ipld-format) - Local (node/block scope) resolver](#ipld-format-specifics---local-nodeblock-scope-resolver)
+  - [IPLD Format Specifics - Local (node/block scope) resolver](#ipld-format-specifics---local-nodeblock-scope-resolver)
     - [`dagPB.resolver.resolve`](#dagpbresolverresolve)
     - [`dagPB.resolver.tree`](#dagpbresolvertree)
-  - [[IPLD Format Specifics](https://github.com/ipld/interface-ipld-format) - util](#ipld-format-specifics---util)
+  - [IPLD Format Specifics - util](#ipld-format-specifics---util)
   - [`dagPB.util.cid`](#dagpbutilcid)
   - [`dagPB.util.serialize`](#dagpbutilserialize)
   - [`dagPB.util.deserialize`](#dagpbutildeserialize)
@@ -87,9 +86,7 @@ const node2 = new DAGNode('some data')
 ```JavaScript
 const link = {
   Name: 'I am a link',
-  Hash: 'QmHash..',
-  Tsize: 42
-}
+  Hash: 'QmHash..'
 
 node.addLink(link)
 console.log('with link', node.toJSON())
@@ -115,7 +112,6 @@ const DAGNode = dagPB.DAGNode
 
 - `data` - type: Buffer
 - `links`- (optional) type: Array of DAGLink instances or Array of DAGLink instances in its json format (link.toJSON)
-- `serializedSize`- (optional) type: Number of bytes the serialized node has. If none is given, it will automatically be calculated.
 
 Create a DAGNode.
 
@@ -127,9 +123,8 @@ links can be a single or an array of DAGLinks instances or objects with the foll
 
 ```JavaScript
 {
-  Name: '<some name>',
   Hash: '<some cid>',
-  TSize: <sizeInBytes>
+  Name: '<some name>'
 }
 ```
 
@@ -142,10 +137,6 @@ You have the following methods and properties available in every DAGNode instanc
 #### `node.Links`
 
 An array of JSON Objects with fields named `Hash`, `Name`, and `Tsize`.
-
-#### `node.size`
-
-Size of the node, in bytes
 
 #### `node.toJSON()`
 
@@ -215,17 +206,14 @@ const DAGLink = dagPB.DAGLink
 ```JavaScript
 // link is a DAGLink instance
 const link = new DAGLink(
-  'link-to-file',  // name of the link (can be empty)
-  10,              // size in bytes
   'QmSomeHash...', // can be CID object, CID buffer or string
+  'link-to-file'  // optional name of the link
 )
 ```
 
 ### DAGLink instance methods and properties
 
 #### `link.Name`
-
-#### `link.Tsize`
 
 #### `link.Hash`
 

--- a/src/dag-link/dagLink.js
+++ b/src/dag-link/dagLink.js
@@ -6,11 +6,8 @@ const withIs = require('class-is')
 
 // Link represents an IPFS Merkle DAG Link between Nodes.
 class DAGLink {
-  constructor (name, cid) {
+  constructor (cid, name) {
     assert(cid, 'A link requires a cid to point to')
-    // assert(size, 'A link requires a size')
-    //  note - links should include size, but this assert is disabled
-    //  for now to maintain consistency with go-ipfs pinset
 
     this._name = name || ''
     this._nameBuf = null

--- a/src/dag-link/dagLink.js
+++ b/src/dag-link/dagLink.js
@@ -6,7 +6,7 @@ const withIs = require('class-is')
 
 // Link represents an IPFS Merkle DAG Link between Nodes.
 class DAGLink {
-  constructor (name, size, cid) {
+  constructor (name, cid) {
     assert(cid, 'A link requires a cid to point to')
     // assert(size, 'A link requires a size')
     //  note - links should include size, but this assert is disabled
@@ -14,19 +14,17 @@ class DAGLink {
 
     this._name = name || ''
     this._nameBuf = null
-    this._size = size
     this._cid = new CID(cid)
   }
 
   toString () {
-    return `DAGLink <${this._cid.toBaseEncodedString()} - name: "${this.Name}", size: ${this.Tsize}>`
+    return `DAGLink <${this._cid.toBaseEncodedString()} - name: "${this.Name}">`
   }
 
   toJSON () {
     if (!this._json) {
       this._json = Object.freeze({
         name: this.Name,
-        size: this.Tsize,
         cid: this.Hash.toBaseEncodedString()
       })
     }
@@ -52,14 +50,6 @@ class DAGLink {
 
   set Name (name) {
     throw new Error("Can't set property: 'name' is immutable")
-  }
-
-  get Tsize () {
-    return this._size
-  }
-
-  set Tsize (size) {
-    throw new Error("Can't set property: 'size' is immutable")
   }
 
   get Hash () {

--- a/src/dag-link/util.js
+++ b/src/dag-link/util.js
@@ -5,7 +5,6 @@ const DAGLink = require('./dagLink')
 function createDagLinkFromB58EncodedHash (link) {
   return new DAGLink(
     link.Name || link.name || '',
-    link.Tsize || link.Size || link.size || 0,
     link.Hash || link.hash || link.multihash || link.cid
   )
 }

--- a/src/dag-link/util.js
+++ b/src/dag-link/util.js
@@ -4,8 +4,8 @@ const DAGLink = require('./dagLink')
 
 function createDagLinkFromB58EncodedHash (link) {
   return new DAGLink(
-    link.Name || link.name || '',
-    link.Hash || link.hash || link.multihash || link.cid
+    link.Hash || link.hash || link.multihash || link.cid,
+    link.Name || link.name
   )
 }
 

--- a/src/dag-node/addLink.js
+++ b/src/dag-node/addLink.js
@@ -21,7 +21,7 @@ const asDAGLink = (link) => {
   }
 
   // It's a Object with name, multihash/hash/cid and size
-  return new DAGLink(link.Name || link.name, link.Hash || link.multihash || link.hash || link.cid)
+  return new DAGLink(link.Hash || link.multihash || link.hash || link.cid, link.Name || link.name)
 }
 
 const addLink = (node, link) => {

--- a/src/dag-node/addLink.js
+++ b/src/dag-node/addLink.js
@@ -21,7 +21,7 @@ const asDAGLink = (link) => {
   }
 
   // It's a Object with name, multihash/hash/cid and size
-  return new DAGLink(link.Name || link.name, link.Tsize || link.size, link.Hash || link.multihash || link.hash || link.cid)
+  return new DAGLink(link.Name || link.name, link.Hash || link.multihash || link.hash || link.cid)
 }
 
 const addLink = (node, link) => {

--- a/src/dag-node/dagNode.js
+++ b/src/dag-node/dagNode.js
@@ -9,7 +9,7 @@ const addLink = require('./addLink')
 const rmLink = require('./rmLink')
 
 class DAGNode {
-  constructor (data, links = [], serializedSize = null) {
+  constructor (data, links = []) {
     if (!data) {
       data = Buffer.alloc(0)
     }
@@ -18,10 +18,6 @@ class DAGNode {
     }
     if (!Buffer.isBuffer(data)) {
       throw new Error('Passed \'data\' is not a buffer or a string!')
-    }
-
-    if (serializedSize !== null && typeof serializedSize !== 'number') {
-      throw new Error('Passed \'serializedSize\' must be a number!')
     }
 
     links = links.map((link) => {
@@ -33,16 +29,13 @@ class DAGNode {
 
     this._data = data
     this._links = links
-    this._serializedSize = serializedSize
-    this._size = null
   }
 
   toJSON () {
     if (!this._json) {
       this._json = Object.freeze({
         data: this.Data,
-        links: this._links.map((l) => l.toJSON()),
-        size: this.size
+        links: this._links.map((l) => l.toJSON())
       })
     }
 
@@ -50,21 +43,14 @@ class DAGNode {
   }
 
   toString () {
-    return `DAGNode <data: "${this.Data.toString('base64')}", links: ${this.Links.length}, size: ${this.size}>`
-  }
-
-  _invalidateCached () {
-    this._serializedSize = null
-    this._size = null
+    return `DAGNode <data: "${this.Data.toString('base64')}", links: ${this.Links.length}>`
   }
 
   addLink (link) {
-    this._invalidateCached()
     return addLink(this, link)
   }
 
   rmLink (link) {
-    this._invalidateCached()
     return rmLink(this, link)
   }
 
@@ -80,21 +66,6 @@ class DAGNode {
     })
   }
 
-  get size () {
-    if (this._size === null) {
-      if (this._serializedSize === null) {
-        this._serializedSize = this.serialize().length
-      }
-      this._size = this._links.reduce((sum, l) => sum + l.Tsize, this._serializedSize)
-    }
-
-    return this._size
-  }
-
-  set size (size) {
-    throw new Error("Can't set property: 'size' is immutable")
-  }
-
   // Getters for backwards compatible path resolving
   get Data () {
     return this._data
@@ -108,7 +79,6 @@ class DAGNode {
     return this._links.map((link) => {
       return {
         Name: link.Name,
-        Tsize: link.Tsize,
         Hash: link.Hash
       }
     })

--- a/src/dag-node/toDagLink.js
+++ b/src/dag-node/toDagLink.js
@@ -8,7 +8,7 @@ const genCid = require('../genCid')
  */
 const toDAGLink = async (node, options = {}) => {
   const nodeCid = await genCid.cid(node.serialize(), options)
-  return new DAGLink(options.name || '', node.size, nodeCid)
+  return new DAGLink(options.name || '', nodeCid)
 }
 
 module.exports = toDAGLink

--- a/src/dag-node/toDagLink.js
+++ b/src/dag-node/toDagLink.js
@@ -8,7 +8,7 @@ const genCid = require('../genCid')
  */
 const toDAGLink = async (node, options = {}) => {
   const nodeCid = await genCid.cid(node.serialize(), options)
-  return new DAGLink(options.name || '', nodeCid)
+  return new DAGLink(nodeCid, options.name)
 }
 
 module.exports = toDAGLink

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -70,7 +70,6 @@ exports.tree = function * (binaryBlob) {
   for (let ii = 0; ii < node.Links.length; ii++) {
     yield `Links/${ii}`
     yield `Links/${ii}/Name`
-    yield `Links/${ii}/Tsize`
     yield `Links/${ii}/Hash`
   }
 }

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -21,8 +21,7 @@ const toProtoBuf = (node) => {
     pbn.Links = node.Links
       .map((link) => ({
         Hash: link.Hash.buffer,
-        Name: link.Name,
-        Tsize: link.Tsize
+        Name: link.Name
       }))
   } else {
     pbn.Links = null

--- a/src/util.js
+++ b/src/util.js
@@ -49,7 +49,7 @@ const deserialize = (buffer) => {
   const pbn = proto.PBNode.decode(buffer)
 
   const links = pbn.Links.map((link) => {
-    return new DAGLink(link.Name, link.Hash)
+    return new DAGLink(link.Hash, link.Name)
   })
 
   const data = pbn.Data == null ? Buffer.alloc(0) : pbn.Data

--- a/src/util.js
+++ b/src/util.js
@@ -49,12 +49,12 @@ const deserialize = (buffer) => {
   const pbn = proto.PBNode.decode(buffer)
 
   const links = pbn.Links.map((link) => {
-    return new DAGLink(link.Name, link.Tsize, link.Hash)
+    return new DAGLink(link.Name, link.Hash)
   })
 
   const data = pbn.Data == null ? Buffer.alloc(0) : pbn.Data
 
-  return new DAGNode(data, links, buffer.length)
+  return new DAGNode(data, links)
 }
 
 exports.serialize = serialize

--- a/test/dag-link-test.js
+++ b/test/dag-link-test.js
@@ -12,19 +12,19 @@ module.exports = (repo) => {
   describe('DAGLink', () => {
     describe('create with multihash as b58 encoded string', () => {
       it('string', () => {
-        const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+        const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
 
         expect(link.Hash.buffer.toString('hex'))
           .to.equal('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43')
       })
 
       it('empty string', () => {
-        const link = new DAGLink('', 4, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+        const link = new DAGLink('', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
         expect(link.Name).to.be.eql('')
       })
 
       it('create with multihash as a multihash Buffer', () => {
-        const link = new DAGLink('hello', 3, Buffer.from('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43', 'hex'))
+        const link = new DAGLink('hello', Buffer.from('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43', 'hex'))
 
         expect(new CID(link.Hash).toBaseEncodedString())
           .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
@@ -39,29 +39,28 @@ module.exports = (repo) => {
     })
 
     it('toJSON', () => {
-      const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+      const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
 
       expect(link.toJSON()).to.eql({
         name: 'hello',
-        size: 3,
         cid: 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'
       })
     })
 
     it('toString', () => {
-      const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+      const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
 
-      expect(link.toString()).to.equal('DAGLink <QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U - name: "hello", size: 3>')
+      expect(link.toString()).to.equal('DAGLink <QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U - name: "hello">')
     })
 
     it('exposes a CID', () => {
       const cid = 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'
-      const link = new DAGLink('hello', 3, cid)
+      const link = new DAGLink('hello', cid)
       expect(link.Hash.toBaseEncodedString()).to.equal(cid)
     })
 
     it('has an immutable CID', () => {
-      const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+      const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
       expect(() => { link.Hash = 'foo' }).to.throw(/property/)
     })
   })

--- a/test/dag-link-test.js
+++ b/test/dag-link-test.js
@@ -12,19 +12,19 @@ module.exports = (repo) => {
   describe('DAGLink', () => {
     describe('create with multihash as b58 encoded string', () => {
       it('string', () => {
-        const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+        const link = new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U', 'hello')
 
         expect(link.Hash.buffer.toString('hex'))
           .to.equal('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43')
       })
 
       it('empty string', () => {
-        const link = new DAGLink('', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+        const link = new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
         expect(link.Name).to.be.eql('')
       })
 
       it('create with multihash as a multihash Buffer', () => {
-        const link = new DAGLink('hello', Buffer.from('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43', 'hex'))
+        const link = new DAGLink(Buffer.from('12208ab7a6c5e74737878ac73863cb76739d15d4666de44e5756bf55a2f9e9ab5f43', 'hex'), 'hello')
 
         expect(new CID(link.Hash).toBaseEncodedString())
           .to.equal('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
@@ -32,14 +32,14 @@ module.exports = (repo) => {
 
       it('fail to create without multihash', () => {
         expect(() => {
-          const link = new DAGLink('hello', 3)
+          const link = new DAGLink()
           expect(link).to.not.exist()
         }).to.throw()
       })
     })
 
     it('toJSON', () => {
-      const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+      const link = new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U', 'hello')
 
       expect(link.toJSON()).to.eql({
         name: 'hello',
@@ -48,19 +48,19 @@ module.exports = (repo) => {
     })
 
     it('toString', () => {
-      const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+      const link = new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U', 'hello')
 
       expect(link.toString()).to.equal('DAGLink <QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U - name: "hello">')
     })
 
     it('exposes a CID', () => {
       const cid = 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'
-      const link = new DAGLink('hello', cid)
+      const link = new DAGLink(cid, 'hello')
       expect(link.Hash.toBaseEncodedString()).to.equal(cid)
     })
 
     it('has an immutable CID', () => {
-      const link = new DAGLink('hello', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+      const link = new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U', 'hello')
       expect(() => { link.Hash = 'foo' }).to.throw(/property/)
     })
   })

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -70,7 +70,7 @@ module.exports = (repo) => {
 
       const node1 = new DAGNode(someData, l1)
       const l2 = l1.map((l) => {
-        return new DAGLink(l.Name, l.Hash)
+        return new DAGLink(l.Hash, l.Name)
       })
 
       const node2 = new DAGNode(someData, l2)
@@ -86,14 +86,14 @@ module.exports = (repo) => {
 
     it('create with empty link name', () => {
       const node = new DAGNode(Buffer.from('hello'), [
-        new DAGLink('', 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+        new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U', '')
       ])
       expect(node.Links[0].Name).to.be.eql('')
     })
 
     it('create with undefined link name', () => {
       const node = new DAGNode(Buffer.from('hello'), [
-        new DAGLink(undefined, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+        new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U', undefined)
       ])
       expect(node.Links[0].Name).to.be.eql('')
       const serialized = node.serialize()
@@ -104,6 +104,13 @@ module.exports = (repo) => {
         }
         expect(node[key]).to.deep.equal(deserialized[key])
       }
+    })
+
+    it('create with null link name', () => {
+      const node = new DAGNode(Buffer.from('hello'), [
+        new DAGLink('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U', null)
+      ])
+      expect(node.Links[0].Name).to.be.eql('')
     })
 
     it('create an empty node', () => {
@@ -377,8 +384,8 @@ module.exports = (repo) => {
         Hash: 'QmP7SrR76KHK9A916RbHG1ufy2TzNABZgiE23PjZDMzZXy'
       }
 
-      const link1 = new DAGLink(l1.Name, Buffer.from(bs58.decode(l1.Hash)))
-      const link2 = new DAGLink(l2.Name, Buffer.from(bs58.decode(l2.Hash)))
+      const link1 = new DAGLink(Buffer.from(bs58.decode(l1.Hash)), l1.Name)
+      const link2 = new DAGLink(Buffer.from(bs58.decode(l2.Hash)), l2.Name)
 
       const node = new DAGNode(Buffer.from('hiya'), [link1, link2])
       expect(node.Links).to.have.lengthOf(2)

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -14,12 +14,10 @@ const utils = require('../src/util')
 describe('IPLD Format resolver (local)', () => {
   const links = [{
     Name: '',
-    Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U'),
-    Tsize: 10
+    Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
   }, {
     Name: 'named link',
-    Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V'),
-    Tsize: 8
+    Hash: new CID('QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V')
   }]
 
   const create = (data, links) => {
@@ -91,12 +89,6 @@ describe('IPLD Format resolver (local)', () => {
         expect(result.remainderPath).to.eql('')
       })
 
-      it('links position path Tsize', () => {
-        const result = resolver.resolve(linksNodeBlob, 'Links/1/Tsize')
-        expect(result.value).to.eql(links[1].Tsize)
-        expect(result.remainderPath).to.eql('')
-      })
-
       it('links by name', () => {
         const result = resolver.resolve(linksNodeBlob, 'named link')
         expect(result.value.equals(links[1].Hash)).to.be.true()
@@ -151,11 +143,9 @@ describe('IPLD Format resolver (local)', () => {
         'Links',
         'Links/0',
         'Links/0/Name',
-        'Links/0/Tsize',
         'Links/0/Hash',
         'Links/1',
         'Links/1/Name',
-        'Links/1/Tsize',
         'Links/1/Hash',
         'Data'
       ])
@@ -199,11 +189,9 @@ describe('IPLD Format resolver (local)', () => {
         'Links',
         'Links/0',
         'Links/0/Name',
-        'Links/0/Tsize',
         'Links/0/Hash',
         'Links/1',
         'Links/1/Name',
-        'Links/1/Tsize',
         'Links/1/Hash',
         'Data'
       ])

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -34,7 +34,7 @@ describe('util', () => {
 
   it('should serialize a node with links', () => {
     const links = [
-      new DAGLink('', 0, 'QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
+      new DAGLink('', 'QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
     ]
     const result = serialize({ Links: links })
     expect(result).to.be.an.instanceof(Uint8Array)
@@ -42,7 +42,6 @@ describe('util', () => {
     const node = deserialize(result)
     expect(node.Links).to.deep.equal([{
       Name: '',
-      Tsize: 0,
       Hash: new CID('QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
     }])
   })
@@ -50,7 +49,6 @@ describe('util', () => {
   it('should serialize a node with links as plain objects', () => {
     const links = [{
       Name: '',
-      Tsize: 0,
       Hash: new CID('QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
     }]
     const result = serialize({ Links: links })

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -34,7 +34,7 @@ describe('util', () => {
 
   it('should serialize a node with links', () => {
     const links = [
-      new DAGLink('', 'QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
+      new DAGLink('QmWDtUQj38YLW8v3q4A6LwPn4vYKEbuKWpgSm6bjKW6Xfe')
     ]
     const result = serialize({ Links: links })
     expect(result).to.be.an.instanceof(Uint8Array)


### PR DESCRIPTION
The size property has been removed from links. In order to maintain backwards compatibility the field is stil present in the protobuf definition but is ignored.

See discussion on https://github.com/ipfs/specs/issues/238 and https://github.com/ipld/specs/pull/234

Fixes #154

BREAKING CHANGE:

* The DAGLink constructor has changed from `DAGLink(name, size, cid)` to `DAGLink(name, cid)`
* The DAGNode constructor has changed from `DAGNode(data, links, serializedSize)` to `DAGNode(data, links)`
* The DAGLink class no long has a `.Tsize` property
* The DAGNode class no longer has `.size` or `._serializedSize` properties