### PR TITLE
fix: remove use of assert module

### DIFF
--- a/src/dag-link/dagLink.js
+++ b/src/dag-link/dagLink.js
@@ -1,13 +1,15 @@
 'use strict'
 
 const CID = require('cids')
-const assert = require('assert')
 const withIs = require('class-is')
 
 // Link represents an IPFS Merkle DAG Link between Nodes.
 class DAGLink {
   constructor (name, size, cid) {
-    assert(cid, 'A link requires a cid to point to')
+    if (!cid) {
+      throw new Error('A link requires a cid to point to')
+    }
+
     // assert(size, 'A link requires a size')
     //  note - links should include size, but this assert is disabled
     //  for now to maintain consistency with go-ipfs pinset


### PR DESCRIPTION
The polyfill is big, we can simulate it by throwing an Error and it doesn't work under React Native.