### PR TITLE
fix: revert stable module removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "class-is": "^1.1.0",
     "multicodec": "^1.0.1",
     "multihashing-async": "~0.8.1",
-    "protons": "^1.0.2"
+    "protons": "^1.0.2",
+    "stable": "^0.1.8"
   },
   "devDependencies": {
     "aegir": "^21.9.0",

--- a/src/dag-node/sortLinks.js
+++ b/src/dag-node/sortLinks.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Buffer } = require('buffer')
+const sort = require('stable')
 
 const linkSort = (a, b) => {
   return Buffer.compare(a.nameAsBuffer, b.nameAsBuffer)
@@ -12,7 +13,7 @@ const linkSort = (a, b) => {
  * @returns {Array}
  */
 const sortLinks = (links) => {
-  return links.sort(linkSort)
+  return sort(links, linkSort)
 }
 
 module.exports = sortLinks

--- a/test/dag-node-test.js
+++ b/test/dag-node-test.js
@@ -90,6 +90,61 @@ module.exports = (repo) => {
       ])
     })
 
+    it('create a node with sorted links', () => {
+      const links = [{
+        Name: '',
+        Hash: new CID('QmUGhP2X8xo9dsj45vqx1H6i5WqPqLqmLQsHTTxd3ke8mp'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmP7SrR76KHK9A916RbHG1ufy2TzNABZgiE23PjZDMzZXy'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmQg1v4o9xdT3Q14wh4S7dxZkDjyZ9ssFzFzyep1YrVJBY'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmdP6fartWRrydZCUjHgrJ4XpxSE4SAoRsWJZ1zJ4MWiuf'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmNNjUStxtMC1WaSZYiDW6CmAUrvd5Q2e17qnxPgVdwrwW'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmWJwqZBJWerHsN1b7g4pRDYmzGNnaMYuD3KSbnpaxsB2h'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmRXPSdysBS3dbUXe6w8oXevZWHdPQWaR2d3fggNsjvieL'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmTUZAXfws6zrhEksnMqLxsbhXZBQs4FNiarjXSYQqVrjC'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmNNk7dTdh8UofwgqLNauq6N78DPc6LKK2yBs1MFdx7Mbg'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmW5mrJfyqh7B4ywSvraZgnWjS3q9CLiYURiJpCX3aro5i'),
+        Tsize: 262158
+      }, {
+        Name: '',
+        Hash: new CID('QmTFHZL5CkgNz19MdPnSuyLAi6AVq9fFp81zmPpaL2amED'),
+        Tsize: 262158
+      }]
+
+      const node = new DAGNode(Buffer.from('some data'), links)
+      const serialized = node.serialize()
+      const deserialized = dagPB.util.deserialize(serialized)
+
+      // check sorting
+      expect(deserialized.Links.map((l) => l.Hash)).to.be.eql(links.map(l => l.Hash))
+    })
+
     it('create with empty link name', () => {
       const node = new DAGNode(Buffer.from('hello'), [
         new DAGLink('', 10, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')


### PR DESCRIPTION
Sorting is not stable on Node 10, adds a test that exposes the bug and reinstates the `stable` module to fix it.

Reverts 3048e3ea76a71f779193f6a24a5ed874d911b562