### PR TITLE
fix: strip control characters from link names

### DIFF
--- a/src/dag-link/dagLink.js
+++ b/src/dag-link/dagLink.js
@@ -16,10 +16,11 @@ class DAGLink {
     //  for now to maintain consistency with go-ipfs pinset
 
     Object.defineProperties(this, {
-      Name: { value: name || '', writable: false, enumerable: true },
+      Name: { value: stripControlChars(name) || '', writable: false, enumerable: true },
       Tsize: { value: size, writable: false, enumerable: true },
       Hash: { value: new CID(cid), writable: false, enumerable: true },
-      _nameBuf: { value: null, writable: true, enumerable: false }
+      _nameBuf: { value: null, writable: true, enumerable: false },
+      _name: { value: name, writable: false, enumerable: false }
     })
   }
 
@@ -50,6 +51,13 @@ class DAGLink {
     this._nameBuf = uint8ArrayFromString(this.Name)
     return this._nameBuf
   }
+}
+
+const stripControlChars = (str) => {
+  return (str || '')
+    .split('')
+    .filter((c) => c.charCodeAt(0) > 31)
+    .join('')
 }
 
 exports = module.exports = withIs(DAGLink, { className: 'DAGLink', symbolName: '@ipld/js-ipld-dag-pb/daglink' })

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -21,7 +21,7 @@ const toProtoBuf = (node) => {
     pbn.Links = node.Links
       .map((link) => ({
         Hash: link.Hash.bytes,
-        Name: link.Name,
+        Name: link._name,
         Tsize: link.Tsize
       }))
   } else {

--- a/test/dag-link-test.spec.js
+++ b/test/dag-link-test.spec.js
@@ -63,4 +63,13 @@ describe('DAGLink', () => {
     const link = new DAGLink('hello', 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
     expect(() => { link.Hash = 'foo' }).to.throw(/read.only/)
   })
+
+  it('strips control codes', () => {
+    const goodChars = 'hello'
+    const badChars = '\b\b'
+
+    const link = new DAGLink(`${goodChars}${badChars}`, 3, 'QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39U')
+    expect(link.Name).to.equal(goodChars)
+    expect(link._name).to.equal(`${goodChars}${badChars}`)
+  })
 })

--- a/test/dag-node-test.spec.js
+++ b/test/dag-node-test.spec.js
@@ -544,4 +544,33 @@ describe('DAGNode', () => {
 
     expect(node.Links[0].Tsize).to.eql(9001)
   })
+
+  it('respects invalid strings when creating a CID', async () => {
+    const goodChars = 'hello'
+    const badChars = '\b\b'
+
+    const linkProps = {
+      Hash: 'QmUxD5gZfKzm8UN4WaguAMAZjw2TzZ2ZUmcqm2qXPtais7',
+      Size: 9001
+    }
+
+    const node1 = new DAGNode(uint8ArrayFromString('some data'), [{
+      Name: goodChars,
+      ...linkProps
+    }])
+
+    const node2 = new DAGNode(uint8ArrayFromString('some data'), [{
+      Name: `${goodChars}${badChars}`,
+      ...linkProps
+    }])
+
+    // should ignore bad characters for name
+    expect(node1.Links[0].Name).to.equal(node2.Links[0].Name)
+
+    // should respect bad characters when serializing
+    const cid1 = await dagPB.util.cid(dagPB.util.serialize(node1))
+    const cid2 = await dagPB.util.cid(dagPB.util.serialize(node2))
+
+    expect(cid1.toString()).to.not.equal(cid2.toString())
+  })
 })


### PR DESCRIPTION
In the case where we receive garbage or malicious strings that contain
characters with a utf code less than 31, strip those character codes
from the link name.

We keep the garbage string around though, so we can de-serialize and
reserialize a node without changing it's CID, though we do not expose
that string to the caller through documented properties.