### PR TITLE
fix: types again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,22 @@
 
 const resolver = require('./resolver')
 const util = require('./util')
-const DAGNode = require('./dag-node/dagNode')
-const DAGLink = require('./dag-link/dagLink')
+const DAGNodeClass = require('./dag-node/dagNode')
+const DAGLinkClass = require('./dag-link/dagLink')
 
 /**
  * @typedef {import('./types').DAGLinkLike} DAGLinkLike
  * @typedef {import('./types').DAGNodeLike} DAGNodeLike
- * @typedef {import('interface-ipld-format').Format<DAGNode>} DAGNodeFormat
+ * @typedef {import('./dag-node/dagNode')} DAGNode
+ * @typedef {import('./dag-link/dagLink')} DAGLink
  */
 
 /**
- * @type {DAGNodeFormat & { DAGNode: DAGNode, DAGLink: DAGLink }}
+ * @type {import('./types').DAGNodeFormat}
  */
-module.exports = {
-  DAGNode,
-  DAGLink,
+const format = {
+  DAGNode: DAGNodeClass,
+  DAGLink: DAGLinkClass,
 
   /**
    * Functions to fulfil IPLD Format interface
@@ -27,3 +28,5 @@ module.exports = {
   codec: util.codec,
   defaultHashAlg: util.defaultHashAlg
 }
+
+module.exports = format

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,7 @@
 import CID from 'cids'
+import { Format } from 'interface-ipld-format'
+import DAGNode from './dag-node/dagNode'
+import DAGLink from './dag-link/dagLink'
 
 export interface DAGLinkLike {
   Hash: CID
@@ -20,4 +23,9 @@ export interface SerializableDAGLink {
 export interface SerializableDAGNode {
   Data?: Uint8Array | null
   Links?: SerializableDAGLink[] | null
+}
+
+export interface DAGNodeFormat extends Format<DAGNode> {
+  DAGNode: typeof DAGNode
+  DAGLink: typeof DAGLink
 }


### PR DESCRIPTION
If we require a JS class `Foo`, then export it as a property of an object,
ts thinks we are exporting `typeof Foo` rather than the `Foo` constructor.

At runtime `typeof` gets erased so ts gets upset by things like:

```js
const { DAGNode } = require('ipld-dag-pb')

if (bar instanceof DAGNode) {
  // ...
}
```

..because as far as ts is concerned, `DAGNode` is actually `typeof DAGNode`
and `typeof DAGNode` has been erased since it's a `typeof` so `ipld-dag-pb`
does not export a property called `DAGNode` and kaboom.

The change here is to use the `types.d.ts` to define the `typeof` we are
exporting-but-not-really-exporting-since-it-gets-erased, use a `@typedef`
in the index file to actually export the type for use elsewhere, then rename
the `require`'d DAGNode/DAGLink classes to stop them conflicting with the
`@typedef` tag.

JS is happy, ts is happy.

Phew.